### PR TITLE
Start microbreak from the menu

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ You can create installer by running `npm run pack` or `npm run dist` after  `npm
 
 ## Running from source
 
-To run app you will need [nodejs](https://nodejs.org/). Clone the repo, run `npm install` and then simply do `npm run` to start *stretchly*.
+To run app you will need [nodejs](https://nodejs.org/). Clone the repo, run `npm install` and then simply do `npm start` to start *stretchly*.
 
 It should run on any electron supported platform. Tested on OS X, Windows and Ubuntu Linux.
 

--- a/app/main.js
+++ b/app/main.js
@@ -94,9 +94,8 @@ function finishMicrobreak (shouldPlaySound = true) {
   planMicrobreakTimer = setTimeout(planMicrobreak, 100)
 }
 
-function planMicrobreak (time) {
-  let startTime = (typeof time === 'number') ? time : settings.get('microbreakInterval')
-  startMicrobreakTimer = setTimeout(startMicrobreak, startTime)
+function planMicrobreak () {
+  startMicrobreakTimer = setTimeout(startMicrobreak, settings.get('microbreakInterval'))
 }
 
 ipcMain.on('finish-microbreak', function (event, shouldPlaySound) {

--- a/app/main.js
+++ b/app/main.js
@@ -95,7 +95,7 @@ function finishMicrobreak (shouldPlaySound = true) {
 }
 
 function planMicrobreak (time) {
-  let startTime = (typeof time === 'number') ? time :settings.get('microbreakInterval')
+  let startTime = (typeof time === 'number') ? time : settings.get('microbreakInterval')
   startMicrobreakTimer = setTimeout(startMicrobreak, startTime)
 }
 

--- a/app/main.js
+++ b/app/main.js
@@ -94,8 +94,9 @@ function finishMicrobreak (shouldPlaySound = true) {
   planMicrobreakTimer = setTimeout(planMicrobreak, 100)
 }
 
-function planMicrobreak () {
-  startMicrobreakTimer = setTimeout(startMicrobreak, settings.get('microbreakInterval'))
+function planMicrobreak (time) {
+  let startTime = (typeof time === 'number') ? time :settings.get('microbreakInterval')
+  startMicrobreakTimer = setTimeout(startMicrobreak, startTime)
 }
 
 ipcMain.on('finish-microbreak', function (event, shouldPlaySound) {

--- a/app/main.js
+++ b/app/main.js
@@ -206,7 +206,7 @@ function getTrayMenu () {
   trayMenu.push({
     label: 'Start a break!',
     click: function () {
-      planMicrobreak(200)
+      startMicrobreak()
     }
   })
 

--- a/app/main.js
+++ b/app/main.js
@@ -202,24 +202,14 @@ function getTrayMenu () {
     }
   }, {
     type: 'separator'
-  }, {
-    label: 'Settings',
+  })
+
+  trayMenu.push({
+    label: 'Start a break!',
     click: function () {
-      showSettingsWindow()
+      planMicrobreak(200)
     }
   })
-  if (process.platform === 'darwin' || process.platform === 'win32') {
-    let loginItemSettings = app.getLoginItemSettings()
-    let openAtLogin = loginItemSettings.openAtLogin
-    trayMenu.push({
-      label: 'Start at login',
-      type: 'checkbox',
-      checked: openAtLogin,
-      click: function () {
-        app.setLoginItemSettings({openAtLogin: !openAtLogin})
-      }
-    })
-  }
 
   if (isPaused) {
     trayMenu.push({
@@ -256,6 +246,27 @@ function getTrayMenu () {
       ]
     })
   }
+
+  trayMenu.push({
+    label: 'Settings',
+    click: function () {
+      showSettingsWindow()
+    }
+  })
+
+  if (process.platform === 'darwin' || process.platform === 'win32') {
+    let loginItemSettings = app.getLoginItemSettings()
+    let openAtLogin = loginItemSettings.openAtLogin
+    trayMenu.push({
+      label: 'Start at login',
+      type: 'checkbox',
+      checked: openAtLogin,
+      click: function () {
+        app.setLoginItemSettings({openAtLogin: !openAtLogin})
+      }
+    })
+  }
+
   trayMenu.push({
     type: 'separator'
   }, {

--- a/app/main.js
+++ b/app/main.js
@@ -69,6 +69,12 @@ function showStartUpWindow () {
 }
 
 function startMicrobreak () {
+  // don't start another break if break running
+  if (microbreakWin) {
+    console.log('microbreak already running')
+    return
+  }
+
   const modalPath = path.join('file://', __dirname, 'microbreak.html')
   microbreakWin = new BrowserWindow({
     frame: false,


### PR DESCRIPTION
I added the functionality to plan a microbreak using a time-based parameter.  Subsequently, I was able to use this new functionality to add the 'Start a break' option to the menu.

Fixed a small Readme bug (at least I think it was a bug) as `npm run` wouldn't get the project going for me.

Also shuffled some things in the tray menu to keep the actionable menu items towards the top.
Hope that helps!