### PR TITLE
Upper limit of microbreak duration set to 300 seconds (5 minutes)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Spanish translations for interface
 - Romanian translations for interface
 
+### Changed
+- upper limit of microbreak duration set to 300 seconds (5 minutes)
+
 ## [0.16.0] - 2018-03-17
 ### Added
 - Russian translations for interface

--- a/app/settings.js
+++ b/app/settings.js
@@ -42,7 +42,7 @@ microbreakIntervalMinus.addEventListener('click', function (e) {
 })
 
 microbreakDurationPlus.addEventListener('click', function (e) {
-  if (microbreakDuration.innerHTML !== '60') {
+  if (microbreakDuration.innerHTML !== '300') {
     ipcRenderer.send('save-setting', 'microbreakDuration', (parseInt(microbreakDuration.innerHTML, 10) + 5) * 1000)
   }
 })


### PR DESCRIPTION
closes #237