### PR TITLE
Fix manual breaks upon suspend/resume

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Welcome and Tutorial windows on first run and in About window
 - Dutch translations for interface
 
+### Fixed
+- User pause will no longer be removed upon suspend/resume
+- User pause time will be corrected upon suspend/resume for the duration
+  of system sleep
+
 ## [0.17.0] - 2018-05-06
 ### Added
 - Ukrainian translations for interface

--- a/README.md
+++ b/README.md
@@ -157,6 +157,7 @@ Before implementing a feature, please open an Issue first, so we can be sure tha
 - Ciprian Rusen, [www.digitalcitizen.life](https://www.digitalcitizen.life)
 - Carlo Gandolfi, @cgand
 - Kavya Jain, @kavya-jain
+- Denys Otrishko, @lundibundi
 
 
 ### Humans and Tools

--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -135,8 +135,8 @@ class BreaksPlanner extends EventEmitter {
     this.nextBreak()
   }
 
-  restart (correctByMillis = 0) {
-    if (this.scheduler) this.scheduler.reload(correctByMillis)
+  correctScheduler () {
+    if (this.scheduler) this.scheduler.correct()
   }
 
   reset () {

--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -135,9 +135,8 @@ class BreaksPlanner extends EventEmitter {
     this.nextBreak()
   }
 
-  correctBy (millis) {
-    if (!this.scheduler) return
-    this.scheduler.reload(millis)
+  restart (correctByMillis = 0) {
+    if (this.scheduler) this.scheduler.reload(correctByMillis)
   }
 
   reset () {

--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -135,6 +135,11 @@ class BreaksPlanner extends EventEmitter {
     this.nextBreak()
   }
 
+  correctBy (millis) {
+    if (!this.scheduler) return
+    this.scheduler.reload(millis)
+  }
+
   reset () {
     this.clear()
     this.resume()

--- a/app/main.js
+++ b/app/main.js
@@ -82,9 +82,7 @@ i18next.on('languageChanged', function (lng) {
 
 function startPowerMonitoring () {
   const electron = require('electron')
-  let suspendStart = Date.now()
   electron.powerMonitor.on('suspend', () => {
-    suspendStart = Date.now()
     if (!breakPlanner.isPaused) {
       pausedForSuspend = true
       pauseBreaks(1)
@@ -95,8 +93,8 @@ function startPowerMonitoring () {
       pausedForSuspend = false
       resumeBreaks()
     } else if (breakPlanner.isPaused) {
-      const suspendDuration = Date.now() - suspendStart
-      breakPlanner.correctBy(suspendDuration)
+      // restart the planner to correct for time spent in suspend
+      breakPlanner.restart()
     }
   })
 }

--- a/app/main.js
+++ b/app/main.js
@@ -83,18 +83,20 @@ i18next.on('languageChanged', function (lng) {
 function startPowerMonitoring () {
   const electron = require('electron')
   electron.powerMonitor.on('suspend', () => {
+    console.log('The system is going to sleep')
     if (!breakPlanner.isPaused) {
       pausedForSuspend = true
       pauseBreaks(1)
     }
   })
   electron.powerMonitor.on('resume', () => {
+    console.log('The system is resuming')
     if (pausedForSuspend) {
       pausedForSuspend = false
       resumeBreaks()
     } else if (breakPlanner.isPaused) {
-      // restart the planner to correct for time spent in suspend
-      breakPlanner.restart()
+      // corrrect the planner for the time spent in suspend
+      breakPlanner.correctScheduler()
     }
   })
 }

--- a/app/main.js
+++ b/app/main.js
@@ -23,7 +23,7 @@ let settingsWin = null
 let tutorialWin = null
 let welcomeWin = null
 let settings
-let isOnIndefinitePause
+let pausedForSuspend = false
 
 app.setAppUserModelId('net.hovancik.stretchly')
 
@@ -82,13 +82,22 @@ i18next.on('languageChanged', function (lng) {
 
 function startPowerMonitoring () {
   const electron = require('electron')
+  let suspendStart = Date.now()
   electron.powerMonitor.on('suspend', () => {
-    console.log('The system is going to sleep')
-    if (!isOnIndefinitePause) pauseBreaks(1)
+    suspendStart = Date.now()
+    if (!breakPlanner.isPaused) {
+      pausedForSuspend = true
+      pauseBreaks(1)
+    }
   })
   electron.powerMonitor.on('resume', () => {
-    console.log('The system is resuming')
-    if (!isOnIndefinitePause) resumeBreaks()
+    if (pausedForSuspend) {
+      pausedForSuspend = false
+      resumeBreaks()
+    } else if (breakPlanner.isPaused) {
+      const suspendDuration = Date.now() - suspendStart
+      breakPlanner.correctBy(suspendDuration)
+    }
   })
 }
 
@@ -402,8 +411,7 @@ function loadIdeas () {
   microbreakIdeas = new IdeasLoader(microbreakIdeasData).ideas()
 }
 
-function pauseBreaks (milliseconds, keepAfterPowerResume = false) {
-  isOnIndefinitePause = keepAfterPowerResume
+function pauseBreaks (milliseconds) {
   if (microbreakWins) {
     finishMicrobreak(false)
   }
@@ -416,7 +424,6 @@ function pauseBreaks (milliseconds, keepAfterPowerResume = false) {
 }
 
 function resumeBreaks () {
-  isOnIndefinitePause = false
   breakPlanner.resume()
   appIcon.setContextMenu(getTrayMenu())
   processWin.webContents.send('showNotification', i18next.t('main.resumingBreaks'))
@@ -569,7 +576,7 @@ function getTrayMenu () {
         }, {
           label: i18next.t('main.indefinitely'),
           click: function () {
-            pauseBreaks(1, true)
+            pauseBreaks(1)
           }
         }
       ]

--- a/app/utils/scheduler.js
+++ b/app/utils/scheduler.js
@@ -5,16 +5,28 @@ class Scheduler {
     this.delay = delay
     this.func = func
     this.reference = reference
+    this._correction = 0
   }
 
   get timeLeft () {
     if (this.timer === null) return false
-    return this.now + this.delay - Date.now()
+    return this.now + this.delay - Date.now() - this._correction
   }
 
   plan () {
+    this._correction = 0
     this.now = Date.now()
     this.timer = setTimeout(this.func, this.delay)
+  }
+
+  reload (correctionMillis) {
+    if (this.timer === null) return
+    clearTimeout(this.timer)
+
+    this._correction += correctionMillis
+    const timeLeft = this.timeLeft
+    if (timeLeft <= 0) this.func()
+    else this.timer = setTimeout(this.func, timeLeft)
   }
 
   cancel () {

--- a/app/utils/scheduler.js
+++ b/app/utils/scheduler.js
@@ -5,28 +5,22 @@ class Scheduler {
     this.delay = delay
     this.func = func
     this.reference = reference
-    this._correction = 0
   }
 
   get timeLeft () {
     if (this.timer === null) return false
-    return this.now + this.delay - Date.now() - this._correction
+    return this.now + this.delay - Date.now()
   }
 
   plan () {
-    this._correction = 0
     this.now = Date.now()
     this.timer = setTimeout(this.func, this.delay)
   }
 
-  reload (correctionMillis) {
+  correct () {
     if (this.timer === null) return
     clearTimeout(this.timer)
-
-    this._correction += correctionMillis
-    const timeLeft = this.timeLeft
-    if (timeLeft <= 0) this.func()
-    else this.timer = setTimeout(this.func, timeLeft)
+    this.timer = setTimeout(this.func, this.timeLeft)
   }
 
   cancel () {

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -25,6 +25,27 @@ describe('scheduler', function () {
     }, 200)
   })
 
+  it('kinda runs schedule on time with reload', function (done) {
+    let time = 1000
+    let correction = 400
+    let start = Date.now()
+    let callback = function () {
+      // allow margin due to event loop delay
+      (Date.now() - start).should.be
+        .within(time - correction, time - correction / 2)
+      test = false
+    }
+    let schedule = new Scheduler(callback, time)
+    schedule.plan()
+    setTimeout(function () {
+      schedule.reload(correction)
+    }, 200)
+    setTimeout(function () {
+      test.should.be.false
+      done()
+    }, time)
+  })
+
   it('it cancels schedule on cancel()', function (done) {
     let time = 100
     let callback = function () {
@@ -55,5 +76,22 @@ describe('scheduler', function () {
       test.should.be.false
       done()
     }, 160)
+  })
+
+  it('it kinda gets the time left with reload', function (done) {
+    let time = 500
+    let correction = 300
+    let schedule = new Scheduler(() => {}, time)
+    schedule.plan()
+    setTimeout(function () {
+      schedule.timeLeft.should.be.a('number').and
+        .to.be.above(400)
+      schedule.reload(correction)
+    }, 50)
+    setTimeout(function () {
+      schedule.timeLeft.should.be.a('number').and
+        .to.be.below(time - correction - 100)
+      done()
+    }, 100)
   })
 })

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -90,7 +90,7 @@ describe('scheduler', function () {
     }, 50)
     setTimeout(function () {
       schedule.timeLeft.should.be.a('number').and
-        .to.be.below(time - correction - 100)
+        .to.be.most(time - correction - 100)
       done()
     }, 100)
   })

--- a/test/scheduler.js
+++ b/test/scheduler.js
@@ -25,25 +25,24 @@ describe('scheduler', function () {
     }, 200)
   })
 
-  it('kinda runs schedule on time with reload', function (done) {
+  it('kinda runs schedule on time with correct', function (done) {
     let time = 1000
-    let correction = 400
     let start = Date.now()
     let callback = function () {
       // allow margin due to event loop delay
       (Date.now() - start).should.be
-        .within(time - correction, time - correction / 2)
+        .within(time - 100, time + 100)
       test = false
     }
     let schedule = new Scheduler(callback, time)
     schedule.plan()
     setTimeout(function () {
-      schedule.reload(correction)
+      schedule.correct()
     }, 200)
     setTimeout(function () {
       test.should.be.false
       done()
-    }, time)
+    }, time + 100)
   })
 
   it('it cancels schedule on cancel()', function (done) {
@@ -76,22 +75,5 @@ describe('scheduler', function () {
       test.should.be.false
       done()
     }, 160)
-  })
-
-  it('it kinda gets the time left with reload', function (done) {
-    let time = 500
-    let correction = 300
-    let schedule = new Scheduler(() => {}, time)
-    schedule.plan()
-    setTimeout(function () {
-      schedule.timeLeft.should.be.a('number').and
-        .to.be.above(400)
-      schedule.reload(correction)
-    }, 50)
-    setTimeout(function () {
-      schedule.timeLeft.should.be.a('number').and
-        .to.be.most(time - correction - 100)
-      done()
-    }, 100)
   })
 })


### PR DESCRIPTION
* Only resume automatic for-suspend break
* If was on break then correct break time based on suspend duration
* Remove unnecessary logging

Issue: https://github.com/hovancik/stretchly/issues/259

closes #259 

### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation.
- [x]  during development, `node` version specified in `package.json` was used.
- [x]  package versions were not changed.
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions. (most does excluding actual suspend/resume testing)
- [x] `npm run lint` reports no offenses. (fails for eslint-chai problems)
- [x] `npm run test` is error-free. (fails on non related test)
- [x]  README and CHANGELOG were updated accordingly.

### Description of the Change

This PR makes so that user breaks are preserved after system suspend/resume and corrects the break time accordingly.
Based on electron issues (see https://github.com/hovancik/stretchly/issues/259#issuecomment-401622387) it needs to be tested on win and mac devices more.
Also I'll add tests and readme/changelog changes later.

### Verification Process

- [x] Verified that it preserves user pause and corrects pause time (via logging pause time and suspending the pc)
- [x] Verified that it pauses/resumes breaks for suspend when the was no user pause (previous behavior) (via logging pause time and suspending the pc)

### Other

Why don't we use node-version list of all supported versions? It seemed to work just fine on node 10.5.0.