### PR TITLE
Fixed italian translation typos, plus minor adjustments

### DIFF
--- a/README.md
+++ b/README.md
@@ -186,6 +186,7 @@ One can use `Ctrl/Cmd + d` shortcut in About window to show debug information:
 - Sabine van der Eijk, @Sabin_E
 - JavaScript Joe, [@jsjoeio](https://github.com/jsjoeio)
 - Ismail Demirbilek, [@dbtek](https://github.com/dbtek)
+- Giacomo Rossetto, [@jackymancs4](https://github.com/jackymancs4)
 
 ### Humans and Tools
  - https://github.com/typefoo/node-icns

--- a/app/locales/bg.json
+++ b/app/locales/bg.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - приложение за напомняне за почивка",
-    "microbreakIn": "Микропочивка след {{seconds}} секунди...",
-    "breakIn": "Почивка след {{seconds}} секунди...",
+    "microbreakIn": "Микропочивка след {{seconds}} секунди…",
+    "breakIn": "Почивка след {{seconds}} секунди…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "...Не!!! Ще продължа...",
+    "keepGoing": "…Не!!! Ще продължа…",
     "title": "Време е за почивка!"
   },
   "microbreak": {
-    "keepGoing": "...Не!!! Ще продължа...",
+    "keepGoing": "…Не!!! Ще продължа…",
     "title": "Време е за почивка!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "последна версия:",
-    "checking": "проверка за нова версия..."
+    "checking": "проверка за нова версия…"
   },
   "settings": {
     "settings": "Настройки",

--- a/app/locales/de.json
+++ b/app/locales/de.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - Pausenzeit Erinnerungs App",
-    "microbreakIn": "Mikropause in {{seconds}} Sekunden...",
-    "breakIn": "Pause in {{seconds}} Sekunden...",
+    "microbreakIn": "Mikropause in {{seconds}} Sekunden…",
+    "breakIn": "Pause in {{seconds}} Sekunden…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIm nicht stören Modus"
   },
   "break": {
-    "keepGoing": "... nein, ich werde weitermachen",
+    "keepGoing": "… nein, ich werde weitermachen",
     "title": "Zeit für eine Pause!"
   },
   "microbreak": {
-    "keepGoing": "... nein, ich werde weitermachen",
+    "keepGoing": "… nein, ich werde weitermachen",
     "title": "Zeit für eine Pause!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "die neuste Version:",
-    "checking": "prüfe..."
+    "checking": "prüfe…"
   },
   "settings": {
     "settings": "Einstellungen",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - break time reminder app",
-    "microbreakIn": "Microbreak in {{seconds}} seconds...",
-    "breakIn": "Break in {{seconds}} seconds...",
+    "microbreakIn": "Microbreak in {{seconds}} seconds…",
+    "breakIn": "Break in {{seconds}} seconds…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "...nah, I'll just keep going on",
+    "keepGoing": "…nah, I'll just keep going on",
     "title": "Time to take a break!"
   },
   "microbreak": {
-    "keepGoing": "...nah, I'll just keep going on",
+    "keepGoing": "…nah, I'll just keep going on",
     "title": "Time to take a break!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "the latest version:",
-    "checking": "checking..."
+    "checking": "checking…"
   },
   "settings": {
     "settings": "Settings",

--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - aplicación para notificar cuándo hacer descansos",
-    "microbreakIn": "Microdescanso en {{seconds}} segundos...",
-    "breakIn": "Descanso en {{seconds}} segundos...",
+    "microbreakIn": "Microdescanso en {{seconds}} segundos…",
+    "breakIn": "Descanso en {{seconds}} segundos…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nEn el modo No Molestar"
   },
   "break": {
-    "keepGoing": "...bah, prefiero seguir",
+    "keepGoing": "…bah, prefiero seguir",
     "title": "Hora de hacer un descanso!"
   },
   "microbreak": {
-    "keepGoing": "...bah, prefiero seguir",
+    "keepGoing": "…bah, prefiero seguir",
     "title": "Hora de hacer un microdescanso!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "última versión:",
-    "checking": "comprobando..."
+    "checking": "comprobando…"
   },
   "settings": {
     "settings": "Configuración",

--- a/app/locales/fr.json
+++ b/app/locales/fr.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - application de rappel de pauses",
-    "microbreakIn": "Petite pause dans {{seconds}} secondes...",
-    "breakIn": "Grande pause dans {{seconds}} secondes...",
+    "microbreakIn": "Petite pause dans {{seconds}} secondes…",
+    "breakIn": "Grande pause dans {{seconds}} secondes…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nEn mode ne pas troubler"
   },
   "break": {
-    "keepGoing": "...non, je vais continuer sans pause",
+    "keepGoing": "…non, je vais continuer sans pause",
     "title": "Il est temps de faire une grande pause !"
   },
   "microbreak": {
-    "keepGoing": "...non, je vais continuer sans pause",
+    "keepGoing": "…non, je vais continuer sans pause",
     "title": "Il est temps de faire une petite pause !"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "la dernière version:",
-    "checking": "vérification..."
+    "checking": "vérification…"
   },
   "settings": {
     "settings": "Paramètres",

--- a/app/locales/hi.json
+++ b/app/locales/hi.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - विराम समय अनुस्मारक एप्लिकेशन",
-    "microbreakIn": " {{seconds}} सेकंड का छोटा ब्रेक ...",
-    "breakIn": "{{seconds}} सेकंड का ब्रेक ...",
+    "microbreakIn": " {{seconds}} सेकंड का छोटा ब्रेक …",
+    "breakIn": "{{seconds}} सेकंड का ब्रेक …",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "...नहीं, मुझे ब्रेक नहीं चाहिए",
+    "keepGoing": "…नहीं, मुझे ब्रेक नहीं चाहिए",
     "title": "ब्रेक लेने का समय आ गया है!"
   },
   "microbreak": {
-    "keepGoing": "...नहीं, मुझे ब्रेक नहीं चाहिए",
+    "keepGoing": "…नहीं, मुझे ब्रेक नहीं चाहिए",
     "title": "ब्रेक लेने का समय आ गया है!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "नया वर्शन:",
-    "checking": "जाँच चालू है ..."
+    "checking": "जाँच चालू है …"
   },
   "settings": {
     "settings": "सेट्टिंग्स",

--- a/app/locales/it.json
+++ b/app/locales/it.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - l'app che ti ricorda quando prenderti una pausa",
-    "microbreakIn": "Micropausa in {{seconds}} secondi...",
-    "breakIn": "Pausa in {{seconds}} secondi...",
+    "microbreakIn": "Micropausa in {{seconds}} secondi…",
+    "breakIn": "Pausa in {{seconds}} secondi…",
     "breakAt": "Prossima {{reference}} alle {{hours}}:{{minutes}}",
     "breakReference": "pausa",
     "microbreakReference": "micropausa",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn modalità non disturbare"
   },
   "break": {
-    "keepGoing": "...no, preferisco non fermarmi",
+    "keepGoing": "…no, preferisco non fermarmi",
     "title": "È ora di fare una pausa!"
   },
   "microbreak": {
-    "keepGoing": "...no, preferisco non fermarmi",
+    "keepGoing": "…no, preferisco non fermarmi",
     "title": "È ora di fare una pausa!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "o leggi il",
     "tutorial": "tutorial",
     "latestVersion": "ultima versione:",
-    "checking": "sto controllando..."
+    "checking": "sto controllando…"
   },
   "settings": {
     "settings": "Impostazioni",

--- a/app/locales/it.json
+++ b/app/locales/it.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - l'app che ti ricorda quando prenderti una pausa",
-    "microbreakIn": "Micropausa in {{seconds}} secondi…",
-    "breakIn": "Pausa in {{seconds}} secondi…",
+    "microbreakIn": "Micropausa in {{seconds}} secondi...",
+    "breakIn": "Pausa in {{seconds}} secondi...",
     "breakAt": "Prossima {{reference}} alle {{hours}}:{{minutes}}",
     "breakReference": "pausa",
     "microbreakReference": "micropausa",
@@ -10,7 +10,7 @@
     "resumingBreaks": "Pause azzerate",
     "aboutStretchly": "Informazioni su stretchly v{{version}}",
     "downloadLatestVersion": "Scarica l'ultima versione",
-    "about": "Informazioni…",
+    "about": "Informazioni",
     "becomePatron": "Diventa un sostenitore",
     "notificationStateMode": "In modalità non disturbare",
     "toBreak": "pausa",
@@ -24,7 +24,7 @@
     "untilMorning": "fino al mattino",
     "indefinitely": "indefinita",
     "resetBreaks": "Azzera le pause",
-    "settings": "Impostazioni…",
+    "settings": "Impostazioni",
     "startAtLogin": "Avvia al login",
     "yourStretchly": "Il tuo stretchly",
     "quitStretchly": "Esci da stretchly",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn modalità non disturbare"
   },
   "break": {
-    "keepGoing": "…no, preferisco non fermarmi",
+    "keepGoing": "...no, preferisco non fermarmi",
     "title": "È ora di fare una pausa!"
   },
   "microbreak": {
-    "keepGoing": "…no, preferisco non fermarmi",
+    "keepGoing": "...no, preferisco non fermarmi",
     "title": "È ora di fare una pausa!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "o leggi il",
     "tutorial": "tutorial",
     "latestVersion": "ultima versione:",
-    "checking": "sto controllando…"
+    "checking": "sto controllando..."
   },
   "settings": {
     "settings": "Impostazioni",
@@ -66,7 +66,7 @@
     "minutes": "minuti",
     "dontLetMeSkipMicrobreaks": "non permettermi di saltare le micropause",
     "breaks": "pause",
-    "minutesBreakAfter": "minuti di pasua dopo",
+    "minutesBreakAfter": "minuti di pausa dopo",
     "microbreaks2": "micropausa",
     "dontLetMeSkipBreaks": "non permettermi di saltare le pause",
     "(every": "(ogni",
@@ -122,7 +122,7 @@
     "stretchly": "benvenuto in stretchly",
     "breakTimeReminderApp": "l'app che ti ricorda quando prenderti una pausa",
     "chooseLanguage": "Per iniziare, scegli la lingua che desideri usare con stretchly:",
-    "readTutorial": "Fai diventare stretchly la tua app preferita dedicandolgi del tempo per renderla tua. Impara come personalizzarla con questo breve tutorial.",
+    "readTutorial": "Fai diventare stretchly la tua app preferita dedicandogli del tempo per renderla tua. Impara come personalizzarla con questo breve tutorial.",
     "tutorial": "tutorial",
     "skipTutorial": "salta il tutorial, lo puoi sempre trovare nella finestra delle Informazioni"
   },
@@ -145,7 +145,7 @@
     "settings2Title": "",
     "settings2Text": "Amiamo tutte le combinazioni di colori ed i suoni alla fine della pausa, quindi non abbiamo saputo decidere quali impostare come predefiniti. Facci felici e scegli il tuo preferito.",
     "settings3Title": "",
-    "settings3Text": "Nell'ultima pagina delle impostazioni, puoi cambiare la lingua del programma ed alcune impostazioni aggiuntive. Probabilmente non avrai bisogno di cambiarle, comunque perché non controllarle?",
+    "settings3Text": "Nell'ultima pagina delle impostazioni, puoi cambiare la lingua del programma ed alcune impostazioni aggiuntive. Probabilmente non avrai bisogno di cambiarle, ma ehi, perché non dargli un'occhiata?",
     "thanksTitle": "Grazie!",
     "thanksText": "Ogni mese occorre molto lavoro per ricordarti di fare una pausa. Speriamo che tutto ciò ti possa aiutare a condurre una vita più equilibrata. Se è così puoi aiutarmi con il pulsante 'Diventa un sostenitore' nel menu della barra."
   }

--- a/app/locales/nl.json
+++ b/app/locales/nl.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - pauze herinnering app",
-    "microbreakIn": "Kleine pauze over {{seconds}} seconden...",
-    "breakIn": "Pauze over {{seconds}} seconden...",
+    "microbreakIn": "Kleine pauze over {{seconds}} seconden…",
+    "breakIn": "Pauze over {{seconds}} seconden…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nNiet storen staat aan"
   },
   "break": {
-    "keepGoing": "...nee, ik werk gewoon door",
+    "keepGoing": "…nee, ik werk gewoon door",
     "title": "Tijd voor een pauze!"
   },
   "microbreak": {
-    "keepGoing": "...nee, ik werk gewoon door",
+    "keepGoing": "…nee, ik werk gewoon door",
     "title": "Tijd voor een pauze!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "of lees de",
     "tutorial": "handleiding",
     "latestVersion": "de laatste versie:",
-    "checking": "controleren..."
+    "checking": "controleren…"
   },
   "settings": {
     "settings": "Instellingen",

--- a/app/locales/pt-BR.json
+++ b/app/locales/pt-BR.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - aplicativo para lembrá-lo de fazer pausas",
-    "microbreakIn": "Micropausa em {{seconds}} segundos...",
-    "breakIn": "Pausa em {{seconds}} segundos...",
+    "microbreakIn": "Micropausa em {{seconds}} segundos…",
+    "breakIn": "Pausa em {{seconds}} segundos…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "...obrigado por me lembrar, mas vou continuar sem fazer a pausa",
+    "keepGoing": "…obrigado por me lembrar, mas vou continuar sem fazer a pausa",
     "title": "É hora de fazer uma pausa longa!"
   },
   "microbreak": {
-    "keepGoing": "...obrigado por me lembrar, mas vou continuar sem fazer a pausa",
+    "keepGoing": "…obrigado por me lembrar, mas vou continuar sem fazer a pausa",
     "title": "É hora de fazer uma pausa rápida!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "a última versão:",
-    "checking": "verificar..."
+    "checking": "verificar…"
   },
   "settings": {
     "settings": "Configurações",

--- a/app/locales/ro.json
+++ b/app/locales/ro.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - aplicația care-ți aduce aminte să iei o pauză",
-    "microbreakIn": "Micropauză în {{seconds}} secunde...",
-    "breakIn": "Pauză în {{seconds}} secunde...",
+    "microbreakIn": "Micropauză în {{seconds}} secunde…",
+    "breakIn": "Pauză în {{seconds}} secunde…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "...nah, Voi continua",
+    "keepGoing": "…nah, Voi continua",
     "title": "Este timpul să iei o pauză!"
   },
   "microbreak": {
-    "keepGoing": "...nah, Voi continua",
+    "keepGoing": "…nah, Voi continua",
     "title": "Este timpul să iei o pauză!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "cea mai nouă versiune:",
-    "checking": "verific..."
+    "checking": "verific…"
   },
   "settings": {
     "settings": "Setari",

--- a/app/locales/ru.json
+++ b/app/locales/ru.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - напоминания о перерывах",
-    "microbreakIn": "Микроперерыв через {{seconds}}с...",
-    "breakIn": "Перерыв через {{seconds}}с...",
+    "microbreakIn": "Микроперерыв через {{seconds}}с…",
+    "breakIn": "Перерыв через {{seconds}}с…",
     "breakAt": "Следующий {{reference}} в {{hours}}:{{minutes}}",
     "breakReference": "перерыв",
     "microbreakReference": "микроперерыв",
@@ -43,11 +43,11 @@
     "notificationStatus": "\nВ режиме 'Не беспокоить'"
   },
   "break": {
-    "keepGoing": "...не, я просто продолжу",
+    "keepGoing": "…не, я просто продолжу",
     "title": "Перерыв!"
   },
   "microbreak": {
-    "keepGoing": "...не, я просто продолжу",
+    "keepGoing": "…не, я просто продолжу",
     "title": "Перерыв!"
   },
   "about": {
@@ -58,7 +58,7 @@
     "orRead": "или прочитайте",
     "tutorial": "руководство",
     "latestVersion": "последняя версия:",
-    "checking": "проверяем..."
+    "checking": "проверяем…"
   },
   "settings": {
     "settings": "Настройки",

--- a/app/locales/sk.json
+++ b/app/locales/sk.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - pamätá si prestávky za vás",
-    "microbreakIn": "Mikroprestávka za {{seconds}} sekúnd...",
-    "breakIn": "Prestávka za {{seconds}} sekúnd...",
+    "microbreakIn": "Mikroprestávka za {{seconds}} sekúnd…",
+    "breakIn": "Prestávka za {{seconds}} sekúnd…",
     "breakAt": "Ďalšia {{reference}} o {{hours}}:{{minutes}}",
     "breakReference": "prestávka",
     "microbreakReference": "mikroprestávka",
@@ -43,11 +43,11 @@
     "notificationStatus": "\nV režime Nerušiť"
   },
   "break": {
-    "keepGoing": "...nie, chcem pokračovať",
+    "keepGoing": "…nie, chcem pokračovať",
     "title": "Čas na prestávku!"
   },
   "microbreak": {
-    "keepGoing": "...nie, chcem pokračovať",
+    "keepGoing": "…nie, chcem pokračovať",
     "title": "Čas na prestávku!"
   },
   "about": {
@@ -58,7 +58,7 @@
     "orRead": "alebo si prečitajte",
     "tutorial": "tutoriál",
     "latestVersion": "najnovšia verzia:",
-    "checking": "kontrolujem..."
+    "checking": "kontrolujem…"
   },
   "settings": {
     "settings": "Nastavenia",

--- a/app/locales/tr.json
+++ b/app/locales/tr.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - mola hatırlatıcı uygulama",
-    "microbreakIn": "{{seconds}} saniiye içinde kısa bir ara...",
-    "breakIn": "{{seconds}} saniye...",
+    "microbreakIn": "{{seconds}} saniiye içinde kısa bir ara…",
+    "breakIn": "{{seconds}} saniye…",
     "breakAt": "Bir sonraki {{reference}}: {{hours}}:{{minutes}}",
     "breakReference": "mola",
     "microbreakReference": "kısa mola",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nBeni Rahatsız Etme modunda"
   },
   "break": {
-    "keepGoing": "...yok, devam edeceğim",
+    "keepGoing": "…yok, devam edeceğim",
     "title": "Mola zamanı!"
   },
   "microbreak": {
-    "keepGoing": "...yok, devam edeceğim",
+    "keepGoing": "…yok, devam edeceğim",
     "title": "Mola zamanı!"
   },
   "about": {
@@ -57,7 +57,7 @@
     "orRead": "veya",
     "tutorial": "öğretici'yi okuyun",
     "latestVersion": "son sürüm:",
-    "checking": "kontrol ediliyor..."
+    "checking": "kontrol ediliyor…"
   },
   "settings": {
     "settings": "Ayarlar",

--- a/app/locales/uk.json
+++ b/app/locales/uk.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - нагадування про перервах",
-    "microbreakIn": "Мікроперерва через {{seconds}} с ...",
-    "breakIn": "Перерва через {{seconds}} с ...",
+    "microbreakIn": "Мікроперерва через {{seconds}} с …",
+    "breakIn": "Перерва через {{seconds}} с …",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -43,11 +43,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "... ні, я просто продовжу",
+    "keepGoing": "… ні, я просто продовжу",
     "title": "Перерва!"
   },
   "microbreak": {
-    "keepGoing": "... ні, я просто продовжу",
+    "keepGoing": "… ні, я просто продовжу",
     "title": "Перерва!"
   },
   "about": {
@@ -58,7 +58,7 @@
     "orRead": "or read its",
     "tutorial": "tutorial",
     "latestVersion": "остання версія:",
-    "checking": "перевіряємо ..."
+    "checking": "перевіряємо …"
   },
   "settings": {
     "settings": "Налаштування",

--- a/app/locales/zh-CN.json
+++ b/app/locales/zh-CN.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - 休息时间提醒应用",
-    "microbreakIn": "短休息间隔 {{seconds}} 秒...",
-    "breakIn": "长时间休息间隔 {{seconds}} 秒...",
+    "microbreakIn": "短休息间隔 {{seconds}} 秒…",
+    "breakIn": "长时间休息间隔 {{seconds}} 秒…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "...额, 我还有事做",
+    "keepGoing": "…额, 我还有事做",
     "title": "该休息一下了!"
   },
   "microbreak": {
-    "keepGoing": "...额, 我还有事做",
+    "keepGoing": "…额, 我还有事做",
     "title": "该休息一下了!"
   },
   "about": {

--- a/app/locales/zh-TW.json
+++ b/app/locales/zh-TW.json
@@ -1,8 +1,8 @@
 {
   "main": {
     "toolTipHeader": "stretchly - 休息提醒軟體",
-    "microbreakIn": "小休息相隔 {{seconds}} 秒...",
-    "breakIn": "長時間休息相隔 {{seconds}} 秒...",
+    "microbreakIn": "小休息相隔 {{seconds}} 秒…",
+    "breakIn": "長時間休息相隔 {{seconds}} 秒…",
     "breakAt": "Next {{reference}} at {{hours}}:{{minutes}}",
     "breakReference": "break",
     "microbreakReference": "microbreak",
@@ -42,11 +42,11 @@
     "notificationStatus": "\nIn Do Not Disturb mode"
   },
   "break": {
-    "keepGoing": "... 阿, 我還有事情要做",
+    "keepGoing": "… 阿, 我還有事情要做",
     "title": "該休息了！"
   },
   "microbreak": {
-    "keepGoing": "... 阿, 我還有事情要做",
+    "keepGoing": "… 阿, 我還有事情要做",
     "title": "該休息了！"
   },
   "about": {


### PR DESCRIPTION

<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [ ]  issue was opened to discuss proposed changes before starting implementation.
- [x]  during development, `node` version specified in `package.json` was used.
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [ ]  README and CHANGELOG were updated accordingly.

### Description of the Change

Hello @hovancik 
I'm quite a fan of your work.
I saw you merged #312 before I was able to comment about a couple of issues in it.
Here I fixed two typos and rephrased some sentences to make them more in line with the english version.

Also I was not really happy about replacing ```...``` with character U+2026 ```…``` (for [references](http://graphemica.com/%E2%80%A6)), mainly because the english locale file (the reference version) use the simple three point ellipsis. So I reverted that, too. Obviously discussion is welcome.

Ping to @cgand