### PR TITLE
Fix 'pause' Spanish translation

### DIFF
--- a/app/locales/es.json
+++ b/app/locales/es.json
@@ -17,7 +17,7 @@
     "toMicrobreak": "microdescanso",
     "skipToTheNext": "Saltar hasta el siguiente",
     "resume": "Reanudar",
-    "pause": "Descanso",
+    "pause": "Pausar",
     "forHour": "por 1 hora",
     "for2Hours": "por 2 horas",
     "for5Hours": "por 5 horas",


### PR DESCRIPTION
Hi!

Sorry I didn't fill all the required issue details.

The current Spanish translation for "pause" is "Descanso" which in English is "break" or "rest" and that's used for the "Pause -> for an hour" menu and so on, so the translation isn't quite correct. The correct translation is "Pausar", which means "To pause".

This translation existed before I added the missing ones. I noticed it when using the app in Spanish :-)