### PR TITLE
Fixes resizable windows

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Russian translations updated
 - Bulgarian translations updated
 
+### Fixed
+- disabled resizing for some windows
+
 ### Added
 - Swedish translations
 - Turkish translations

--- a/app/main.js
+++ b/app/main.js
@@ -185,6 +185,7 @@ function createWelcomeWindow () {
     welcomeWin = new BrowserWindow({
       x: displaysX(),
       y: displaysY(),
+      resizable: false,
       autoHideMenuBar: true,
       icon: `${__dirname}/images/stretchly_18x18.png`,
       backgroundColor: settings.get('mainColor')
@@ -203,6 +204,7 @@ function createTutorialWindow () {
   tutorialWin = new BrowserWindow({
     x: displaysX(),
     y: displaysY(),
+    resizable: false,
     autoHideMenuBar: true,
     icon: `${__dirname}/images/stretchly_18x18.png`,
     backgroundColor: settings.get('mainColor')
@@ -292,6 +294,7 @@ function startMicrobreak () {
       icon: `${__dirname}/images/stretchly_18x18.png`,
       x: displaysX(displayIdx),
       y: displaysY(displayIdx),
+      resizable: false,
       frame: false,
       show: false,
       backgroundColor: settings.get('mainColor'),
@@ -352,6 +355,7 @@ function startBreak () {
       icon: `${__dirname}/images/stretchly_18x18.png`,
       x: displaysX(displayIdx),
       y: displaysY(displayIdx),
+      resizable: false,
       frame: false,
       show: false,
       backgroundColor: settings.get('mainColor'),


### PR DESCRIPTION
Issue: closes #344


### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation.
- [ ]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).  
*Node v10.6.0 was used*
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.  
*Not required*
- [x] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.  
*"stretchly" test failed because of "windows-notification-state" module (I wasn't able to launch with `npm start` because of this as well). However I successfully created NSIS package and tested the app.*
- [x]  README and CHANGELOG were updated accordingly.


### Description of the Change

Added `resizable: false` for all visible `BrowserWindow` objects.


### Verification Process

Tested whether break windows are resizable on Windows 8. They are not :)


### Other information

I got little experience with node.js, so it's better to check again whether I ruined something.