### PR TITLE
Workaround macOS fullscreen and multiple displays

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -7,6 +7,7 @@ Have you read Code of Conduct? By filing an Issue, you are expected to comply wi
 ### Prerequisites
 
 - [ ] I'm using latest version: v <!-- type your version from `About` window -->
+- [ ] I've checked [Known issues](https://github.com/hovancik/stretchly#known-issues)
 
 ### Description
 

--- a/README.md
+++ b/README.md
@@ -137,8 +137,8 @@ One can use `Ctrl/Cmd + d` shortcut in About window to show debug information:
 ### Known issues
 - tray tooltip does not work correctly on macOS ([electron/electron#9447](https://github.com/electron/electron/issues/9447))
 - fullscreen does not work on Linux ([electron/electron#11632](https://github.com/electron/electron/issues/11632))
+- fullscreen is not shown on all displays on Windows ([electron/electron#16907](https://github.com/electron/electron/issues/16907))
 - power monitoring not working properly ([electron/electron#8560](https://github.com/electron/electron/issues/8560))
-- notifications not working on the latest Win 10 ([electron/electron#10864](https://github.com/electron/electron/issues/10864))
 - tray icon is not rendered correctly on Linux ([electron/electron#12791](https://github.com/electron/electron/issues/12791))
 
 ### TODOs and Ideas

--- a/app/main.js
+++ b/app/main.js
@@ -311,7 +311,7 @@ function startMicrobreak () {
       title: 'stretchly'
     }
 
-    if (!settings.get('fullscreen')) {
+    if  (!(settings.get('fullscreen') && process.platform === 'win32')) {
       windowOptions.x = displaysX(displayIdx)
       windowOptions.y = displaysY(displayIdx)
     }
@@ -391,7 +391,7 @@ function startBreak () {
       title: 'stretchly'
     }
 
-    if (!settings.get('fullscreen')) {
+    if  (!(settings.get('fullscreen') && process.platform === 'win32')) {
       windowOptions.x = displaysX(displayIdx)
       windowOptions.y = displaysY(displayIdx)
     }


### PR DESCRIPTION
closes #383, #375 