### PR TITLE
fitscreen advanced setting added

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - pause breaks when screen is locked (Windows, macOS)
+- fitscreen advanced setting is added
 
 ## [0.20.1] - 2019-07-14
 ### Added

--- a/README.md
+++ b/README.md
@@ -100,6 +100,9 @@ In the settings file, set `notifyNewVersion: false,` to disable new version noti
 #### Play sound at the start of the micro/break
 In the settings file, set `microbreakStartSoundPlaying: true,` to start a microbreak with a sound. Same for `breakStartSoundPlaying`.
 
+#### Fit screen for non-full screen break windows
+In the settings file, change `fitscreen: false,` to `fitscreen: true,`. This will make break windows to render to fill/fit the screen(s) instead of 800x600 windows.
+
 ## Install [![Github All Releases](https://img.shields.io/github/downloads/hovancik/stretchly/total.svg)](https://github.com/hovancik/stretchly/releases/latest)
 
 Latest installers for macOS, Windows, Linux and FreeBSD can be found [here](https://github.com/hovancik/stretchly/releases).

--- a/app/main.js
+++ b/app/main.js
@@ -117,37 +117,34 @@ function closeWindows (windowArray) {
   }
 }
 
-function displaysX (displayID = -1, width = 800) {
+function displaysBounds (displayID = -1) {
   const electron = require('electron')
   let theScreen
   if (displayID === -1) {
     theScreen = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
   } else if (displayID >= numberOfDisplays() || displayID < 0) {
     // Graceful handling of invalid displayID
-    console.log('warning: invalid displayID to displaysX')
+    console.log('warning: invalid displayID to displaysXorY')
     theScreen = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
   } else {
     const screens = electron.screen.getAllDisplays()
     theScreen = screens[displayID]
   }
-  const bounds = theScreen.bounds
+  return {
+    x: theScreen.bounds.x,
+    y: theScreen.bounds.y,
+    width: theScreen.workAreaSize.width,
+    height: theScreen.workAreaSize.height
+  }
+}
+
+function displaysX (displayID = -1, width = 800) {
+  const bounds = displaysBounds(displayID)
   return Math.ceil(bounds.x + ((bounds.width - width) / 2))
 }
 
 function displaysY (displayID = -1, height = 600) {
-  const electron = require('electron')
-  let theScreen
-  if (displayID === -1) {
-    theScreen = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
-  } else if (displayID >= numberOfDisplays()) {
-    // Graceful handling of invalid displayID
-    console.log('warning: invalid displayID to displaysY')
-    theScreen = electron.screen.getDisplayNearestPoint(electron.screen.getCursorScreenPoint())
-  } else {
-    const screens = electron.screen.getAllDisplays()
-    theScreen = screens[displayID]
-  }
-  const bounds = theScreen.bounds
+  const bounds = displaysBounds(displayID)
   return Math.ceil(bounds.y + ((bounds.height - height) / 2))
 }
 
@@ -349,6 +346,14 @@ function startMicrobreak () {
       windowOptions.y = displaysY(displayIdx)
     }
 
+    if (settings.get('fitscreen')) {
+      const bounds = displaysBounds(displayIdx)
+      windowOptions.width = bounds.width
+      windowOptions.height = bounds.height
+      windowOptions.x = displaysX(displayIdx, bounds.width)
+      windowOptions.y = displaysX(displayIdx, bounds.height)
+    }
+
     const microbreakWinLocal = new BrowserWindow(windowOptions)
     // microbreakWinLocal.webContents.openDevTools()
     microbreakWinLocal.once('ready-to-show', () => {
@@ -436,6 +441,14 @@ function startBreak () {
     if (!(settings.get('fullscreen') && process.platform === 'win32')) {
       windowOptions.x = displaysX(displayIdx)
       windowOptions.y = displaysY(displayIdx)
+    }
+
+    if (settings.get('fitscreen')) {
+      const bounds = displaysBounds(displayIdx)
+      windowOptions.width = bounds.width
+      windowOptions.height = bounds.height
+      windowOptions.x = displaysX(displayIdx, bounds.width)
+      windowOptions.y = displaysX(displayIdx, bounds.height)
     }
 
     const breakWinLocal = new BrowserWindow(windowOptions)

--- a/app/utils/defaultSettings.js
+++ b/app/utils/defaultSettings.js
@@ -23,6 +23,7 @@ module.exports = {
   mainColor: '#478484',
   audio: 'crystal-glass',
   fullscreen: false,
+  fitscreen: false,
   ideas: true,
   naturalBreaks: true,
   allScreens: true,


### PR DESCRIPTION
### Requirements

- [ ]  issue was opened to discuss proposed changes before starting implementation.

This is a new change, not related with an issue.

- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.

### Description of the Change

This is a minor addition to advanced settings where the default non-fullscreen break windows is displayed 800x600 sized windows. Having full screen enabled causes macOS to treat each full screen window as a brand new "space" in the expose/mission control. This is too much change and feels heavier when macos does animate this behavior heavily. Keeping windows not full screen is also not obstructive enough to make me stop working, sometimes writing and seeing cursor below the break window can be ignored easily.

I've added a flag in settings (false by default, so no change of behavior by default). The flag sets break window size and position to cover all "work area" size (fit screen except menubar on macOS, full screen on other OSes).

I also moved the common block that determines display's bound size that is used in displaysX and displaysY to a new method displaysBound method which should reduce deduped code.


### Verification Process

Tested in different screen sizes, multiple monitors/external. Also this feature's setting is disabled by default, so there won't be any change in standard behavior of stretchly app.