### PR TITLE
Tweak/center break content

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - German translations updated
 - no notification is shown after system resume/unlock
 - no notification is shown after manual resume of pause from tray menu
+- Break contents are vertically centered
+- Missing Turkish strings added
 
 ### Added
 - pause breaks when screen is locked (Windows, macOS)

--- a/app/break.html
+++ b/app/break.html
@@ -7,10 +7,12 @@
   </head>
   <body>
     <div class="microbreak">
-      <div class="break-idea"></div>
-      <div class="break-text"></div>
-      <progress id='progress' max="10000" ></progress><br/>
-      <p id='progress-time'></p>
+			<div class="center-content">
+				<div class="break-idea"></div>
+				<div class="break-text"></div>
+				<progress id='progress' max="10000" ></progress><br/>
+				<p id='progress-time'></p>
+			</div>
       <a id="postpone" title="Ctrl/Cmd + x" data-i18next="break.postpone"></a>
       <a id="close" title="Ctrl/Cmd + x" data-i18next="break.keepGoing"></a>
     </div>

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -41,6 +41,13 @@ body.darwin {
   padding-top: 10%;
 }
 
+.microbreak .center-content {
+	position: absolute;
+	top: 50%;
+	transform: translateY(-50%);
+	width: 80%;
+}
+
 .tutorial,
 .welcome {
   padding-top: 5px;

--- a/app/locales/tr.json
+++ b/app/locales/tr.json
@@ -42,12 +42,12 @@
     "notificationStatus": "\nBeni Rahatsız Etme modunda"
   },
   "break": {
-    "postpone": "…wait for a bit",
+    "postpone": "…az sonra",
     "keepGoing": "…yok, devam edeceğim",
     "title": "Mola zamanı!"
   },
   "microbreak": {
-    "postpone": "…wait for a bit",
+    "postpone": "…az sonra",
     "keepGoing": "…yok, devam edeceğim",
     "title": "Mola zamanı!"
   },
@@ -66,8 +66,8 @@
     "microbreaks": "kısa molalar",
     "secondsEveryBreak": "saniyeliğine her",
     "minutes": "dakikada",
-    "dontLetMeSkip": "don't let me skip",
-    "allowToPostpone": "allow to postpone",
+    "dontLetMeSkip": "geçmeme izin verme",
+    "allowToPostpone": "ertelememe izin verme",
     "breaks": "molalar",
     "minutesBreakAfter": "dakikalığına her",
     "microbreaks2": "kısa molada",
@@ -101,9 +101,9 @@
     "notifyBeforeBreakStarts": "mola başlamadan önce bildir",
     "notifyBeforeMicrobreakStarts": "kısa mola başlamadan önce bildir",
     "monitorIdleTime": "doğal mola zamanlaması için sistem kullanımını izle",
-    "monitorDnd": "monitor Do Not Disturb mode",
+    "monitorDnd": "Rahatsız-etme modunu izle",
     "showOnAllScreens": "molalar tüm ekranlarda gözüksün",
-    "silentNotifications": "silent notifications",
+    "silentNotifications": "sessiz hatırlatıcılar",
     "useMonochromeTrayIcon": "görev çubuğunda monokrom simge kullan",
     "language": "dil",
     "resetToDefaults": "varsayılanlara sıfırla"

--- a/app/microbreak.html
+++ b/app/microbreak.html
@@ -7,9 +7,11 @@
   </head>
   <body>
     <div class="microbreak">
-      <div class="microbreak-idea"></div>
-      <progress id='progress' max="10000" ></progress><br/>
-      <p id='progress-time'></p>
+			<div class="center-content">
+				<div class="microbreak-idea"></div>
+				<progress id='progress' max="10000" ></progress><br/>
+				<p id='progress-time'></p>
+			</div>
       <a id="postpone" title="Ctrl/Cmd + x" data-i18next="microbreak.postpone"></a>
       <a id="close" title="Ctrl/Cmd + x" data-i18next="microbreak.keepGoing"></a>
     </div>


### PR DESCRIPTION
### Requirements

- [ ]  issue was opened to discuss proposed changes before starting implementation.

These changes are no fix for issues, additions or minor tweaks.

- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.

### Description of the Change

"full screen" (and fitscreen) breaks statically positon the break title, idea and progressbar in the screen. I've added a wrapper to the static content (excluding buttons) and css-centered vertically in the screen.

Added 4-5 missing Turkish translation strings that were in english in tr locale file.