### PR TITLE
Make buttons more obvious

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Improved grammar of microbreak ideas
 - display checkbox list vertically in settings screen 3
 - Dutch translations updated
+- drop shadow on hover for time changing buttons
 
 ### Fixed
 - Ctrl+X global shortcut not being released after `Reset breaks` and `Skip to`

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ You can copy debug information to clipboard.
 - Luke Arms, [lkrms](https://github.com/lkrms)
 - Chris Heyer, [@cheyer](https://github.com/cheyer)
 - Sheri Richardson, [@sheriallis](https://github.com/sheriallis/)
+- Richard Liu, [@richyliu](https://github.com/richyliu/)
 
 ### Humans and Tools
  - https://www.icoconverter.com/ to generate .ico

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -76,6 +76,21 @@ a {
   cursor: pointer;
 }
 
+.change-button {
+  font-size: inherit;
+  font-family: inherit;
+  background-color: inherit;
+  border: none;
+  color: inherit;
+  padding: 0;
+  border-radius: 100px;
+  width: 2rem;
+  transition: box-shadow 0.5s;
+}
+.change-button:hover {
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
+}
+
 .break-idea,
 .microbreak-idea,
 .about-name,

--- a/app/css/app.css
+++ b/app/css/app.css
@@ -85,10 +85,70 @@ a {
   padding: 0;
   border-radius: 100px;
   width: 2rem;
-  transition: box-shadow 0.5s;
+  box-shadow: inset 2px 2px 5px rgba(0, 0, 0, 0.3);
 }
 .change-button:hover {
   box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
+}
+
+/* The checkbox-wrapper */
+.checkbox-wrapper {
+  display: inline;
+  position: relative;
+  padding-left: 1.5em;
+  margin-bottom: 10px;
+  margin-left: 10px;
+  cursor: pointer;
+  font-size: inherit;
+}
+.checkbox-wrapper label {
+  cursor: inherit;
+}
+/* Hide the browser's default checkbox */
+.checkbox-wrapper input {
+  position: absolute;
+  opacity: 0;
+  cursor: pointer;
+  height: 1em;
+  width: 1em;
+  top: 0;
+  left: 0;
+  margin: 0;
+  z-index: 10;
+}
+/* Create a custom checkbox */
+.checkbox-custom {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 1em;
+  width: 1em;
+  z-index: 0;
+  box-shadow: inset 2px 2px 5px rgba(0, 0, 0, 0.3);
+  border-radius: 100px;
+}
+/* On mouse-over, add a box shadow like the + and - buttons */
+.checkbox-wrapper:hover input ~ .checkbox-custom {
+  box-shadow: 2px 2px 2px rgba(0, 0, 0, 0.3);
+}
+/* Create the custom white checkmark (hidden when not checked) */
+.checkbox-custom:after {
+  content: "";
+  position: absolute;
+  display: none;
+  left: 0.36em;
+  top: 0.2em;
+  width: 0.2em;
+  height: 0.4em;
+  border: solid white;
+  border-width: 0 2px 2px 0;
+  -webkit-transform: rotate(45deg);
+  -ms-transform: rotate(45deg);
+  transform: rotate(45deg);
+}
+/* Show the checkbox-custom when checked */
+.checkbox-wrapper input:checked ~ .checkbox-custom:after {
+  display: block;
 }
 
 .break-idea,

--- a/app/settings.html
+++ b/app/settings.html
@@ -8,13 +8,13 @@
     <div class="settings">
       <h2 data-i18next="settings.microbreaks"></h2>
       <p>
-        <span id="microbreakDurationMinus" class="pointer">-</span>
+        <button id="microbreakDurationMinus" class="change-button pointer">-</button>
         <span id="microbreakDuration"></span>
-        <span id="microbreakDurationPlus" class="pointer">+</span>
+        <button id="microbreakDurationPlus" class="change-button pointer">+</button>
         <span data-i18next="settings.secondsEveryBreak"></span>
-        <span id="microbreakIntervalMinus" class="pointer">-</span>
+        <button id="microbreakIntervalMinus" class="change-button pointer">-</button>
         <span id="microbreakInterval"></span>
-        <span id="microbreakIntervalPlus" class="pointer">+</span>
+        <button id="microbreakIntervalPlus" class="change-button pointer">+</button>
         <span data-i18next="settings.minutes"></span>
         <span class="strict">
           <br/>
@@ -26,13 +26,13 @@
       </p>
       <h2 data-i18next="settings.breaks"></h2>
       <p>
-        <span id="breakDurationMinus" class="pointer">-</span>
+        <button id="breakDurationMinus" class="change-button pointer">-</button>
         <span id="breakDuration"></span>
-        <span id="breakDurationPlus" class="pointer">+</span>
+        <button id="breakDurationPlus" class="change-button pointer">+</button>
         <span data-i18next="settings.minutesBreakAfter"></span>
-        <span id="breakIntervalMinus" class="pointer">-</span>
+        <button id="breakIntervalMinus" class="change-button pointer">-</button>
         <span id="breakInterval"></span>
-        <span id="breakIntervalPlus" class="pointer">+</span>
+        <button id="breakIntervalPlus" class="change-button pointer">+</button>
         <span data-i18next="settings.microbreaks2"></span> <br/>
         <small><span data-i18next="settings.(every"></span> <span id="realBreakInterval" ></span> <span data-i18next="settings.minutes)"></small>
         <span class="strict">

--- a/app/settings.html
+++ b/app/settings.html
@@ -18,10 +18,16 @@
         <span data-i18next="settings.minutes"></span>
         <span class="strict">
           <br/>
-          <input type="checkbox" value="microbreakPostpone" class="enable" id="microbreakPostpone">
-          <label data-i18next="settings.allowToPostpone" for="microbreakPostpone"></label>
-          <input type="checkbox" value="microbreakStrictMode" class="enable" id="microbreakStrictMode">
-          <label data-i18next="settings.dontLetMeSkip" for="microbreakStrictMode"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="microbreakPostpone" class="enable" id="microbreakPostpone">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings.allowToPostpone" for="microbreakPostpone"></label>
+          </span>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="microbreakStrictMode" class="enable" id="microbreakStrictMode">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings.dontLetMeSkip" for="microbreakStrictMode"></label>
+          </span>
         </span>
       </p>
       <h2 data-i18next="settings.breaks"></h2>
@@ -37,20 +43,32 @@
         <small><span data-i18next="settings.(every"></span> <span id="realBreakInterval" ></span> <span data-i18next="settings.minutes)"></small>
         <span class="strict">
           <br/>
-          <input type="checkbox" value="breakPostpone" class="enable" id="breakPostpone">
-          <label data-i18next="settings.allowToPostpone" for="breakPostpone"></label>
-          <input type="checkbox" value="breakStrictMode" class="enable" id="breakStrictMode">
-          <label data-i18next="settings.dontLetMeSkip" for="breakStrictMode"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="breakPostpone" class="enable" id="breakPostpone">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings.allowToPostpone" for="breakPostpone"></label>
+          </span>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="breakStrictMode" class="enable" id="breakStrictMode">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings.dontLetMeSkip" for="breakStrictMode"></label>
+          </span>
         </span>
       </p>
       <div>
         <div class="enabled">
-          <input type="checkbox" value="microbreak" class="enable enabletype" id="microbreakCheckbox">
-          <label data-i18next="settings.microbreaksEnabled" for="microbreakCheckbox"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="microbreak" class="enable enabletype" id="microbreakCheckbox">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings.microbreaksEnabled" for="microbreakCheckbox"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="break" class="enable enabletype" id="breakCheckbox">
-          <label data-i18next="settings.breaksEnabled" for="breakCheckbox"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="break" class="enable enabletype" id="breakCheckbox">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings.breaksEnabled" for="breakCheckbox"></label>
+          </span>
         </div>
         <div id="defaults" class="pointer">
           <span data-i18next="settings.resetToDefaults"></span>

--- a/app/settings3.html
+++ b/app/settings3.html
@@ -9,44 +9,74 @@
       <h2 data-i18next="settings3.miscellaneous"></h2>
       <div class="settings-list">
         <div class="enabled">
-          <input type="checkbox" value="fullscreen" class="enable" id="breaksAreFullscreen">
-          <label data-i18next="settings3.breaksAreFullscreen" for="breaksAreFullscreen"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="fullscreen" class="enable" id="breaksAreFullscreen">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.breaksAreFullscreen" for="breaksAreFullscreen"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="ideas" class="enable" id="showBreakIdeas">
-          <label data-i18next="settings3.showBreakIdeas" for="showBreakIdeas"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="ideas" class="enable" id="showBreakIdeas">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.showBreakIdeas" for="showBreakIdeas"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="breakNotification" class="enable" id="notifyBeforeBreakStarts">
-          <label data-i18next="settings3.notifyBeforeBreakStarts" for="notifyBeforeBreakStarts"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="breakNotification" class="enable" id="notifyBeforeBreakStarts">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.notifyBeforeBreakStarts" for="notifyBeforeBreakStarts"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="microbreakNotification" class="enable" id="notifyBeforeMicrobreakStarts">
-          <label data-i18next="settings3.notifyBeforeMicrobreakStarts" for="notifyBeforeMicrobreakStarts"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="microbreakNotification" class="enable" id="notifyBeforeMicrobreakStarts">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.notifyBeforeMicrobreakStarts" for="notifyBeforeMicrobreakStarts"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="silentNotifications" class="enable" id="silentNotifications">
-          <label data-i18next="settings3.silentNotifications" for="silentNotifications"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="silentNotifications" class="enable" id="silentNotifications">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.silentNotifications" for="silentNotifications"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="naturalBreaks" class="enable" id="monitorIdleTime">
-          <label data-i18next="settings3.monitorIdleTime" for="monitorIdleTime"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="naturalBreaks" class="enable" id="monitorIdleTime">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.monitorIdleTime" for="monitorIdleTime"></label>
+          </span>
         </div>
         <div class="enabled linux-hidden">
-          <input type="checkbox" value="monitorDnd" class="enable" id="monitorDnd">
-          <label data-i18next="settings3.monitorDnd" for="monitorDnd"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="monitorDnd" class="enable" id="monitorDnd">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.monitorDnd" for="monitorDnd"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="allScreens" class="enable" id="showOnAllScreens">
-          <label data-i18next="settings3.showOnAllScreens" for="showOnAllScreens"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="allScreens" class="enable" id="showOnAllScreens">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.showOnAllScreens" for="showOnAllScreens"></label>
+          </span>
         </div>
         <div class="enabled">
-          <input type="checkbox" value="useMonochromeTrayIcon" class="enable" id="useMonochromeTrayIcon">
-          <label data-i18next="settings3.useMonochromeTrayIcon" for="useMonochromeTrayIcon"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="useMonochromeTrayIcon" class="enable" id="useMonochromeTrayIcon">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.useMonochromeTrayIcon" for="useMonochromeTrayIcon"></label>
+          </span>
         </div>
         <div class="enabled darwin-hidden">
-          <input type="checkbox" value="useMonochromeInvertedTrayIcon" class="enable" id="useMonochromeInvertedTrayIcon">
-          <label data-i18next="settings3.useMonochromeInvertedTrayIcon" for="useMonochromeInvertedTrayIcon"></label>
+          <span class="checkbox-wrapper">
+            <input type="checkbox" value="useMonochromeInvertedTrayIcon" class="enable" id="useMonochromeInvertedTrayIcon">
+            <span class="checkbox-custom"></span>
+            <label data-i18next="settings3.useMonochromeInvertedTrayIcon" for="useMonochromeInvertedTrayIcon"></label>
+          </span>
         </div>
       </div>
       <h2 data-i18next="settings3.language"></h2>


### PR DESCRIPTION
<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: #420 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation.
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.

### Description of the Change
I added a inset shadow and a drop shadow on hover to the "+" and "-" buttons on the settings page. I also changed the checkboxes to this style as well. This should make it more obvious to the user that they are buttons.

![Screenshot from 2019-10-22 20-14-27](https://user-images.githubusercontent.com/9328196/67353909-9a5f6f80-f508-11e9-8cc3-166fa9bce51e.png)

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->


### Verification Process
I tried clicking on the buttons to make sure the click listeners still work. I tried checking the checkboxes to make sure they still save the checked state.

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->


### Other information
I noticed some other checkboxes in `app/contributor-settings.html`, but I didn't change them because I didn't know how to access them. I didn't change the "skip this break" button on the break timer because it didn't look too well.