### PR TITLE
Add unsplash image as background

### DIFF
--- a/app/css/app.css
+++ b/app/css/app.css
@@ -24,6 +24,15 @@ body {
   user-select: none;
 }
 
+.image-bg{
+  background-image: url("https://source.unsplash.com/random/featured/?nature/");
+  height: 100vh;
+  width: 100vw;
+  background-position: center;
+  background-repeat: no-repeat;
+  background-size: cover;
+}
+
 body.darwin {
   font-family: 'Lato Thin';
 }

--- a/app/microbreak.html
+++ b/app/microbreak.html
@@ -6,12 +6,14 @@
     <link rel="stylesheet" type="text/css" href="css/app.css">
   </head>
   <body>
-    <div class="microbreak">
-      <div class="microbreak-idea"></div>
-      <progress id='progress' max="10000" ></progress><br/>
-      <p id='progress-time'></p>
-      <a id="postpone" title="Ctrl/Cmd + x" data-i18next="microbreak.postpone"></a>
-      <a id="close" title="Ctrl/Cmd + x" data-i18next="microbreak.keepGoing"></a>
+    <div class="image-bg">
+      <div class="microbreak">
+        <div class="microbreak-idea"></div>
+        <progress id='progress' max="10000" ></progress><br/>
+        <p id='progress-time'></p>
+        <a id="postpone" title="Ctrl/Cmd + x" data-i18next="microbreak.postpone"></a>
+        <a id="close" title="Ctrl/Cmd + x" data-i18next="microbreak.keepGoing"></a>
+      </div>
     </div>
     <script>
       require('./platform.js')


### PR DESCRIPTION

Issue: #160 
Fixes #160 
Added unsplash image as background for microbreak.

### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation.
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.
- [ ]  README and CHANGELOG were updated accordingly.

### Description of the Change
Added random unsplash image as background for microbreak. 

### Verification Process
Screenshots   
![Screenshot from 2020-03-24 15-50-04](https://user-images.githubusercontent.com/33183263/77414523-30b0fd80-6de7-11ea-863a-d3d7fce9afb6.png)
