### PR TITLE
Add command-line automation features

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -942,82 +942,84 @@ function showNotification (text) {
 }
 
 function runCommand (event, argv, workingDirectory) {
-  argv.shift()
-  argv.shift()
-  let command = argv.shift()
-  if (!command) {
-    command = 'help'
-  }
-  switch (command) {
-    case 'reset-breaks':
-      console.log('Calling resetBreaks()')
-      resetBreaks()
-      break
-
-    case 'skip-to-microbreak':
-      console.log('Calling skipToMicrobreak()')
-      skipToMicrobreak()
-      break
-
-    case 'skip-to-break':
-      console.log('Calling skipToBreak()')
-      skipToBreak()
-      break
-
-    case 'pause-breaks': {
-      let duration = argv.shift()
-      if (!duration) {
-        duration = 'indefinitely'
-      }
-      let milliseconds
-      switch (duration) {
-        case 'indefinitely':
-          milliseconds = 1
-          break
-        case 'until-morning':
-          milliseconds = new UntilMorning(settings).timeUntilMorning()
-          break
-        default: {
-          const seconds = parseInt(duration)
-          if (isNaN(seconds)) {
-            console.error(command + ': invalid duration \'' + duration + '\'')
-          } else {
-            milliseconds = seconds * 1000
-          }
-          break
-        }
-      }
-      if (milliseconds) {
-        console.log('Calling pauseBreaks(' + milliseconds + ')')
-        pauseBreaks(milliseconds)
-      }
-      break
+  const args = argv.slice(0)
+  let command
+  do {
+    command = args.shift()
+    if (!command) {
+      command = 'help'
     }
-    case 'resume-breaks':
-      if (!breakPlanner.isPaused) {
-        console.log(command + ': breaks not currently paused, resume unavailable')
-      } else {
-        console.log('Calling resumeBreaks()')
-        resumeBreaks(false)
+    switch (command) {
+      case 'reset-breaks':
+        console.log('Calling resetBreaks()')
+        resetBreaks()
+        break
+
+      case 'skip-to-microbreak':
+        console.log('Calling skipToMicrobreak()')
+        skipToMicrobreak()
+        break
+
+      case 'skip-to-break':
+        console.log('Calling skipToBreak()')
+        skipToBreak()
+        break
+
+      case 'pause-breaks': {
+        let duration = args.shift()
+        if (!duration) {
+          duration = 'indefinitely'
+        }
+        let milliseconds
+        switch (duration) {
+          case 'indefinitely':
+            milliseconds = 1
+            break
+          case 'until-morning':
+            milliseconds = new UntilMorning(settings).timeUntilMorning()
+            break
+          default: {
+            const seconds = parseInt(duration)
+            if (isNaN(seconds)) {
+              console.error(command + ': invalid duration \'' + duration + '\'')
+            } else {
+              milliseconds = seconds * 1000
+            }
+            break
+          }
+        }
+        if (milliseconds) {
+          console.log('Calling pauseBreaks(' + milliseconds + ')')
+          pauseBreaks(milliseconds)
+        }
+        break
       }
-      break
+      case 'resume-breaks':
+        if (!breakPlanner.isPaused) {
+          console.log(command + ': breaks not currently paused, resume unavailable')
+        } else {
+          console.log('Calling resumeBreaks()')
+          resumeBreaks(false)
+        }
+        break
 
-    case 'help':
-      console.log('Usage: ' + path.basename(process.execPath) + ' <command> [arguments]\n' +
-        '\n  Commands available:' +
-        '\n    reset-breaks' +
-        '\n    skip-to-microbreak' +
-        '\n    skip-to-break' +
-        '\n    pause-breaks [indefinitely|until-morning|<seconds>]' +
-        '\n      Default: indefinitely' +
-        '\n    resume-breaks'
-      )
-      break
+      case 'help':
+        console.log('Usage: ' + path.basename(process.execPath) + ' <command> [arguments]\n' +
+          '\n  Commands available:' +
+          '\n    reset-breaks' +
+          '\n    skip-to-microbreak' +
+          '\n    skip-to-break' +
+          '\n    pause-breaks [indefinitely|until-morning|<seconds>]' +
+          '\n      Default: indefinitely' +
+          '\n    resume-breaks'
+        )
+        break
 
-    default:
-      console.error('Unknown command: ' + command)
-      break
-  }
+      default:
+        command = false
+        break
+    }
+  } while (!command)
 }
 
 ipcMain.on('postpone-microbreak', function (event, shouldPlaySound) {

--- a/app/main.js
+++ b/app/main.js
@@ -46,6 +46,7 @@ app.on('ready', startProcessWin)
 app.on('ready', loadSettings)
 app.on('ready', createTrayIcon)
 app.on('ready', startPowerMonitoring)
+app.on('second-instance', runCommand)
 app.on('window-all-closed', () => {
   // do nothing, so app wont get closed
 })
@@ -924,7 +925,7 @@ function typeOfBreak () {
       breakNotification = true
       break
     }
-    default : {
+    default: {
       breakType = null
       breakNotification = null
       break
@@ -938,6 +939,85 @@ function showNotification (text) {
     text: text,
     silent: settings.get('silentNotifications')
   })
+}
+
+function runCommand (event, argv, workingDirectory) {
+  argv.shift()
+  argv.shift()
+  let command = argv.shift()
+  if (!command) {
+    command = 'help'
+  }
+  switch (command) {
+    case 'reset-breaks':
+      console.log('Calling resetBreaks()')
+      resetBreaks()
+      break
+
+    case 'skip-to-microbreak':
+      console.log('Calling skipToMicrobreak()')
+      skipToMicrobreak()
+      break
+
+    case 'skip-to-break':
+      console.log('Calling skipToBreak()')
+      skipToBreak()
+      break
+
+    case 'pause-breaks': {
+      let duration = argv.shift()
+      if (!duration) {
+        duration = 'indefinitely'
+      }
+      let milliseconds
+      switch (duration) {
+        case 'indefinitely':
+          milliseconds = 1
+          break
+        case 'until-morning':
+          milliseconds = new UntilMorning(settings).timeUntilMorning()
+          break
+        default: {
+          const seconds = parseInt(duration)
+          if (isNaN(seconds)) {
+            console.error(command + ': invalid duration \'' + duration + '\'')
+          } else {
+            milliseconds = seconds * 1000
+          }
+          break
+        }
+      }
+      if (milliseconds) {
+        console.log('Calling pauseBreaks(' + milliseconds + ')')
+        pauseBreaks(milliseconds)
+      }
+      break
+    }
+    case 'resume-breaks':
+      if (!breakPlanner.isPaused) {
+        console.log(command + ': breaks not currently paused, resume unavailable')
+      } else {
+        console.log('Calling resumeBreaks()')
+        resumeBreaks(false)
+      }
+      break
+
+    case 'help':
+      console.log('Usage: ' + path.basename(process.execPath) + ' <command> [arguments]\n' +
+        '\n  Commands available:' +
+        '\n    reset-breaks' +
+        '\n    skip-to-microbreak' +
+        '\n    skip-to-break' +
+        '\n    pause-breaks [indefinitely|until-morning|<seconds>]' +
+        '\n      Default: indefinitely' +
+        '\n    resume-breaks'
+      )
+      break
+
+    default:
+      console.error('Unknown command: ' + command)
+      break
+  }
 }
 
 ipcMain.on('postpone-microbreak', function (event, shouldPlaySound) {


### PR DESCRIPTION
Issue: https://github.com/hovancik/stretchly/issues/458

### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation.
- [ ]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.
- [ ]  README and CHANGELOG were updated accordingly.

### Description of the Change

Commenced implementation of changes discussed in https://github.com/hovancik/stretchly/issues/458

For now, the following is supported:

```
Usage: stretchly <command> [arguments]

  Commands available:
    reset-breaks
    skip-to-microbreak
    skip-to-break
    pause-breaks [indefinitely|until-morning|<seconds>]
      Default: indefinitely
    resume-breaks
```

### Verification Process

I've confirmed that the commands listed above are received and actioned correctly by the running instance of Stretchly, whether called via `npm start` or from a freshly built AppImage.

### Other information

I anticipate additional commands and improvements will be needed before this is production-ready.