### PR TITLE
Add cross-env to allow 'npm run dev' on Windows

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1046,6 +1046,58 @@
         "readable-stream": "^2.0.0"
       }
     },
+    "cross-env": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-7.0.2.tgz",
+      "integrity": "sha512-KZP/bMEOJEDCkDQAyRhu3RL2ZO/SUVrxQVI0G3YEQ+OLbRA3c6zgixe8Mq8a/z7+HKlNEjo8oiLUs8iRijY2Rw==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.1"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.2",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.2.tgz",
+          "integrity": "sha512-PD6G8QG3S4FK/XCGFbEQrDqO2AnMMsy0meR7lerlIOHAAbkuavGU/pOqprrlvfTNjvowivTeBsjebAL0NSoMxw==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   },
   "scripts": {
     "start": "electron ./app",
-    "dev": "NODE_ENV='development' electron ./app --enable-logging --remote-debugging-port=9222",
+    "dev": "cross-env NODE_ENV=development electron ./app --enable-logging --remote-debugging-port=9222",
     "electromon": "electromon ./app",
     "postinstall": "electron-builder install-app-deps",
     "pack-all": "electron-builder build --dir -mwl --x64 --ia32",
@@ -40,6 +40,7 @@
     "babel-eslint": "^10.0.3",
     "chai": "^4.2.0",
     "chai-as-promised": "^7.1.1",
+    "cross-env": "^7.0.2",
     "electromon": "^1.0.10",
     "electron": "^7.1.9",
     "electron-builder": "20.44.4",


### PR DESCRIPTION
Issue: closes #577

### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation. Trivial change, but I opened an issue.
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [ ]  package versions and package-lock.json were not changed (`npm install --no-save`). This had to be changed to add `cross-env`
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free. Tests were not passing on my machine without this change either.
- [x]  README and CHANGELOG were updated accordingly. No relevant changes.

### Description of the Change

Very trivial change, just added https://www.npmjs.com/package/cross-env and tested if everything worked.
