### PR TITLE
Handle windows focus assist

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+## Added
+- breaks are paused if the Windows 10 Focus Assist mode is enabled
+
 ### Changed
 - updated Polish translation
 - updated Chinese translations

--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ You can copy debug information to the clipboard.
 - Felix W. Dekker, [@FWDekker](https://github.com/FWDekker)
 - Balazs Nasz, [@balazsnasz](https://github.com/balazsnasz)
 - Daniel Bankmann, [@dbankmann](https://github.com/dbankmann)
+- Aziks, [@Aziks0](https://github.com/Aziks0)
 
 Also see Github's list of [contributors](https://github.com/hovancik/stretchly/graphs/contributors).
 

--- a/app/package-lock.json
+++ b/app/package-lock.json
@@ -121,6 +121,15 @@
       "resolved": "https://registry.npmjs.org/sprintf-js/-/sprintf-js-1.0.3.tgz",
       "integrity": "sha1-BOaSb2YolTVPPdAVIDYzuFcpfiw="
     },
+    "windows-focus-assist": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/windows-focus-assist/-/windows-focus-assist-1.2.1.tgz",
+      "integrity": "sha512-FNHBMVKgPIHrTOW17p5YwHAQACUKzYBrs5pmz9LtvqJppGXFM/wHPdcb5ZR/+JknWStE3rvLcBt9hJz0r3Acwg==",
+      "requires": {
+        "bindings": "^1.5.0",
+        "nan": "^2.13.2"
+      }
+    },
     "windows-notification-state": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/windows-notification-state/-/windows-notification-state-1.3.4.tgz",

--- a/app/package.json
+++ b/app/package.json
@@ -24,7 +24,8 @@
     "i18next": "^19.6.2",
     "i18next-node-fs-backend": "^2.1.3",
     "moment": "^2.27.0",
-    "semver": "^7.3.2"
+    "semver": "^7.3.2",
+    "windows-focus-assist": "1.2.1"
   },
   "devDependencies": {}
 }

--- a/app/utils/dndManager.js
+++ b/app/utils/dndManager.js
@@ -26,7 +26,12 @@ class DndManager extends EventEmitter {
 
   get _doNotDisturb () {
     if (this.monitorDnd) {
-      return require('@meetfranz/electron-notification-state').getDoNotDisturb()
+      let focusAssist
+      try {
+        focusAssist = require('windows-focus-assist').getFocusAssist().value
+      } catch (e) { focusAssist = -1 } // getFocusAssist() throw an error if OS isn't windows
+
+      return require('@meetfranz/electron-notification-state').getDoNotDisturb() || (focusAssist !== -1 && focusAssist !== 0)
     } else {
       return false
     }


### PR DESCRIPTION
<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: closes #645 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation.
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [ ]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.

### Description of the Change
Focus Assist mode is available since the Windows 10 version 1803.

![image](https://user-images.githubusercontent.com/36425380/89466964-10218880-d775-11ea-85b1-f18b837974d7.png)

For W10 version above 1803:
- When the Windows Focus Assist mode switches to "Priority only" or "Alarms only", Stretchly breaks are paused
- When the Focus Assist mode switches to "Off", breaks are resumed

For W10 version older than 1803/Linux/MacOS:
- Stretchly works exactly like before


### Verification Process
I've tried on Windows v1903 and it works as expected:
- When Focus Assist mode is on "Priority only" or "Alarms only", breaks are paused
- When Focus Assist mode is on "Off", breaks are resumed

I've tried on Windows v1703 and it works like before:
- When DND (Quiet Hours) is on, breaks are paused.
- When DND (Quiet Hours) is off, breaks are resumed.

On Linux and MacOS, it will normally work like before.


### Other information
[Known Issue #1](https://github.com/hovancik/stretchly#known-issues) might be resolved if users upgrade to a Windows 10 version above 1803.

 