### PR TITLE
Improve command line support

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -500,7 +500,7 @@ function startBreak () {
   breakWins = []
 
   const defaultNextIdea = settings.get('ideas') ? breakIdeas.randomElement : ['', '']
-  const idea = nextIdea.map((val, index) => val || defaultNextIdea[index])
+  const idea = nextIdea ? (nextIdea.map((val, index) => val || defaultNextIdea[index])) : defaultNextIdea
   nextIdea = null
 
   if (settings.get('breakStartSoundPlaying') && !settings.get('silentNotifications')) {


### PR DESCRIPTION
Issue: #567 and #700 

### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change

#### Fixes a regression bug introduced by #570 

No more exception when reaching a long break

#### Add parsing duration features

Changes the way `pause -d` works from seconds, to parsing a duration like `1h20m`. Examples added, and instructions updated.

### Verification Process

For regression bug : let stretchly run until long pause (in progress)

For parsing duration, I added related tests

Sorry for this little bug !
