### PR TITLE
Update en.json: fix typo 'langauge' -> 'language'

### DIFF
--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -48,7 +48,7 @@
       "allScreens": "Shows breaks on all monitors",
       "monitorIdleTime": "Monitor system idle time (breaks are paused if system is idle).",
       "monitorDnd": "Show breaks even in Do Not Disturb mode",
-      "language": "Select langauge:",
+      "language": "Select language:",
       "restoreDefaults": "Restore defaults"
     },
     "schedule": {


### PR DESCRIPTION
Issue: closes #763

### Requirements

- [ ]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
Simple typo fix.
- [ ]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
Simple typo fix.
- [X]  package versions and package-lock.json were not changed (`npm install --no-save`).
Simple typo fix.
- [X]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
Simple typo fix.
- [ ] `npm run lint` reports no offenses.
Simple typo fix.
- [ ] `npm run test` is error-free.
Simple typo fix.
- [ ]  README and CHANGELOG were updated accordingly.
Simple typo fix.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)
It is already a single commit: simple typo fix.

### Description of the Change

Simple typo fix.

### Verification Process

I only updated the text in the Github interface.  I did not try to build on my PC nor was I able to find back the corresponding file in my locally installed copy.
