### PR TITLE
fix chrome tabs being unresponsive after break

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - notification of new version being showed even disabled
+- browser tab non-responsive after resuming
 
 ## [1.3.0] - 2020-11-08
 ### Added

--- a/app/main.js
+++ b/app/main.js
@@ -125,6 +125,7 @@ function numberOfDisplays () {
 
 function closeWindows (windowArray) {
   for (let i = windowArray.length - 1; i >= 0; i--) {
+    windowArray[i].hide()
     windowArray[i].close()
   }
   return null


### PR DESCRIPTION
<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: closes #783
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change
Fixed the issue of chrome and edge tabs being non-responsive when resuming after a break.

### Other information
Not sure if this is an electron or chrome/edge bug and this feels more a workaround than a real fix.
