### PR TITLE
Fix error on Windows and Linux systems when temporary directory is not executable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Fixed
 - prevent empty break windows
 - improve window positioning
+- error on Windows and Linux systems when temporary directory is not executable
 
 ## [1.7.0] - 2021-05-04
 ### Added

--- a/package.json
+++ b/package.json
@@ -75,12 +75,18 @@
         "pacman",
         "tar.xz",
         "apk"
-      ]
+      ],
+      "asarUnpack": "node_modules/macos-notification-state/**"
     },
     "win": {
       "target": [
         "nsis",
         "7z"
+      ],
+      "asarUnpack": [
+        "node_modules/windows-quiet-hours/**",
+        "node_modules/windows-notification-state/**",
+        "node_modules/macos-notification-state/**"
       ]
     },
     "nsis": {


### PR DESCRIPTION
Issue: closes #976 

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.
- [x]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

Proposed change is not unit-testable. `npm run test` fails with
```
  1) UntilMorning
       Sunrise Settings
         msToSunrise() returns morning time the same day:
     AssertionError: expected 7213000 to be within 3540000..3660000
      at Context.<anonymous> (test/untilMorning.js:70:60)
      at processImmediate (internal/timers.js:461:21)

  2) UntilMorning
       Sunrise Settings
         msToSunrise() returns morning time the next day:
     AssertionError: expected 86413000 to be within 82740000..82860000
      at Context.<anonymous> (test/untilMorning.js:75:60)
      at processImmediate (internal/timers.js:461:21)
```
even without my changes.

### Description of the Change

Added `asarUnpack` for `macos-notification-state` and `windows-notification-state` as previously discussed: https://github.com/hovancik/stretchly/issues/976#issuecomment-862346150.

### Verification Process

On Linux:
1. Built from sources locally (`npm install`, `npm run pack`, `npm run dist`).
2. Ran the binary to confirm the presence of error mentioned in https://github.com/hovancik/stretchly/issues/976.
3. Added `asarUnpack` and rebuilt.
4. The error has disappeared.

Windows have not been tested: running `electron-builder` with Wine didn't produce a working binary, and setting up a compiler on Windows is quite a hassle.

macOS builds are not touched, but they may have the same problem, see https://github.com/hovancik/stretchly/issues/976#issuecomment-867972972.