### PR TITLE
Add systemd user unit for linux builds

### DIFF
--- a/distribution/stretchly.service
+++ b/distribution/stretchly.service
@@ -1,0 +1,14 @@
+[Unit]
+Description="Start stretchly"
+After=default.target
+
+[Service]
+Type=simple
+ExecStartPre=/bin/sleep 1
+ExecStart=/usr/bin/stretchly
+Restart=on-failure
+RestartSec=10
+KillMode=process
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
Issue: #984 

### Requirements
- [X]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them
- [ ]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [ ]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [X]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [X] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.
- [ ]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change
Add systemd user unit for linux builds. This doesn't do anything on it's own, the user or package manager can choose to do something with it, which will allow for auto-starting stretchly on system login or whenever the user chooses to start it by using `systemctl` tool.

### Verification Process
N/A - no new functionality added

### Other information
Not sure the best place to put the file, so I make a new distribution directory.