### PR TITLE
Allow the next break or microbreak to be scheduled from the CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 - advanced option for app exclusion check interval
-- support Apple silicon
+- build for Apple silicon
+- ability to schedule break from command line
 
 ## [1.9.0] - 2021-12-24
 ### Changed

--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -168,22 +168,26 @@ class BreaksPlanner extends EventEmitter {
     this.emit('updateToolTip')
   }
 
-  skipToMicrobreak () {
+  scheduleMicrobreak (delay) {
     this.scheduler.cancel()
     const shouldBreak = this.settings.get('break')
     const shouldMicrobreak = this.settings.get('microbreak')
-    const breakInterval = this.settings.get('breakInterval') + 1
     if (shouldBreak && shouldMicrobreak) {
+      const breakInterval = this.settings.get('breakInterval') + 1
       if (this.breakNumber % breakInterval === 0) {
         this.breakNumber = 1
       }
     }
-    this.scheduler = new Scheduler(() => this.emit('startMicrobreak'), 100, 'startMicrobreak')
+    this.scheduler = new Scheduler(() => this.emit('startMicrobreak'), delay, 'startMicrobreak')
     this.scheduler.plan()
     this.emit('updateToolTip')
   }
 
-  skipToBreak () {
+  skipToMicrobreak () {
+    this.scheduleMicrobreak(100)
+  }
+
+  scheduleBreak (delay) {
     this.scheduler.cancel()
     const shouldBreak = this.settings.get('break')
     const shouldMicrobreak = this.settings.get('microbreak')
@@ -191,9 +195,13 @@ class BreaksPlanner extends EventEmitter {
       const breakInterval = this.settings.get('breakInterval') + 1
       this.breakNumber = breakInterval
     }
-    this.scheduler = new Scheduler(() => this.emit('startBreak'), 100, 'startBreak')
+    this.scheduler = new Scheduler(() => this.emit('startBreak'), delay, 'startBreak')
     this.scheduler.plan()
     this.emit('updateToolTip')
+  }
+
+  skipToBreak () {
+    this.scheduleBreak(100)
   }
 
   clear () {

--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -168,7 +168,7 @@ class BreaksPlanner extends EventEmitter {
     this.emit('updateToolTip')
   }
 
-  scheduleMicrobreak (delay) {
+  skipToMicrobreak (delay = 100) {
     this.scheduler.cancel()
     const shouldBreak = this.settings.get('break')
     const shouldMicrobreak = this.settings.get('microbreak')
@@ -183,11 +183,7 @@ class BreaksPlanner extends EventEmitter {
     this.emit('updateToolTip')
   }
 
-  skipToMicrobreak () {
-    this.scheduleMicrobreak(100)
-  }
-
-  scheduleBreak (delay) {
+  skipToBreak (delay = 100) {
     this.scheduler.cancel()
     const shouldBreak = this.settings.get('break')
     const shouldMicrobreak = this.settings.get('microbreak')
@@ -198,10 +194,6 @@ class BreaksPlanner extends EventEmitter {
     this.scheduler = new Scheduler(() => this.emit('startBreak'), delay, 'startBreak')
     this.scheduler.plan()
     this.emit('updateToolTip')
-  }
-
-  skipToBreak () {
-    this.scheduleBreak(100)
   }
 
   clear () {

--- a/app/main.js
+++ b/app/main.js
@@ -97,25 +97,25 @@ if (!gotTheLock) {
 
       case 'mini': {
         log.info('Stretchly: skip to Mini Break (requested by second instance)')
-        const ms = cmd.waitToMs()
-        if (ms === -1) {
+        const delay = cmd.waitToMs()
+        if (delay === -1) {
           log.error('Stretchly: error parsing wait interval to ms because of invalid value')
           return
         }
         if (cmd.options.title) nextIdea = [cmd.options.title]
-        if (!cmd.options.noskip || ms) skipToMicrobreak(ms)
+        if (!cmd.options.noskip || delay) skipToMicrobreak(delay)
         break
       }
 
       case 'long': {
         log.info('Stretchly: skip to Long Break (requested by second instance)')
-        const ms = cmd.waitToMs()
-        if (ms === -1) {
+        const delay = cmd.waitToMs()
+        if (delay === -1) {
           log.error('Stretchly: error parsing wait interval to ms because of invalid value')
           return
         }
         nextIdea = [cmd.options.title ? cmd.options.title : null, cmd.options.text ? cmd.options.text : null]
-        if (!cmd.options.noskip || ms) skipToBreak(ms)
+        if (!cmd.options.noskip || delay) skipToBreak(delay)
         break
       }
 
@@ -132,13 +132,13 @@ if (!gotTheLock) {
 
       case 'pause': {
         log.info('Stretchly: pause Breaks (requested by second instance)')
-        const ms = cmd.durationToMs(settings)
+        const duration = cmd.durationToMs(settings)
         // -1 indicates an invalid value
-        if (ms === -1) {
+        if (duration === -1) {
           log.error('Stretchly: error when parsing duration to ms because of invalid value')
           return
         }
-        pauseBreaks(ms)
+        pauseBreaks(duration)
         break
       }
     }
@@ -955,7 +955,7 @@ function postponeBreak (shouldPlaySound = false) {
   updateTray()
 }
 
-function skipToMicrobreak (delay = 0) {
+function skipToMicrobreak (delay) {
   if (microbreakWins) {
     microbreakWins = breakComplete(false, microbreakWins)
   }
@@ -963,7 +963,7 @@ function skipToMicrobreak (delay = 0) {
     breakWins = breakComplete(false, breakWins)
   }
   if (delay) {
-    breakPlanner.scheduleMicrobreak(delay)
+    breakPlanner.skipToMicrobreak(delay)
     log.info(`Stretchly: skipping to Mini Break in ${delay}ms`)
   } else {
     breakPlanner.skipToMicrobreak()
@@ -972,7 +972,7 @@ function skipToMicrobreak (delay = 0) {
   updateTray()
 }
 
-function skipToBreak (delay = 0) {
+function skipToBreak (delay) {
   if (microbreakWins) {
     microbreakWins = breakComplete(false, microbreakWins)
   }
@@ -980,7 +980,7 @@ function skipToBreak (delay = 0) {
     breakWins = breakComplete(false, breakWins)
   }
   if (delay) {
-    breakPlanner.scheduleBreak(delay)
+    breakPlanner.skipToBreak(delay)
     log.info(`Stretchly: skipping to Long Break in ${delay}ms`)
   } else {
     breakPlanner.skipToBreak()

--- a/app/process.js
+++ b/app/process.js
@@ -8,7 +8,6 @@ const log = require('electron-log')
 const path = require('path')
 log.transports.file.resolvePath = () => path.join(remote.app.getPath('userData'), 'logs/main.log')
 
-
 window.onload = (e) => {
   ipcRenderer.on('playSound', (event, file, volume) => {
     const audio = new Audio(`audio/${file}.wav`)

--- a/app/utils/commands.js
+++ b/app/utils/commands.js
@@ -20,6 +20,12 @@ const allOptions = {
     description: 'Do not skip directly to this break (Long or Mini)',
     withValue: false
   },
+  wait: {
+    long: '--wait',
+    short: '-w',
+    description: 'Specify an interval to wait before skipping to this break (Long or Mini) [HHhMMm|HHh|MMm|MM]',
+    withValue: true
+  },
   duration: {
     long: '--duration',
     short: '-d',
@@ -50,11 +56,11 @@ const allCommands = {
   },
   mini: {
     description: 'Skip to the Mini Break, customize it',
-    options: [allOptions.title, allOptions.noskip]
+    options: [allOptions.title, allOptions.noskip, allOptions.wait]
   },
   long: {
     description: 'Skip to the Long Break, customize it',
-    options: [allOptions.text, allOptions.title, allOptions.noskip]
+    options: [allOptions.text, allOptions.title, allOptions.noskip, allOptions.wait]
   }
 }
 
@@ -145,7 +151,7 @@ class Command {
       })
 
       if (!valid) {
-        log.error(`Stretchly ${this.isFirstInstance ? '' : '2'}: options '${name}' is not valid for command '${this.command}'`)
+        log.error(`Stretchly${this.isFirstInstance ? '' : ' 2'}: option '${name}' is not valid for command '${this.command}'`)
       }
     }
 
@@ -164,7 +170,7 @@ class Command {
 
       default:
         if (this.hasSupportedCommand) {
-          log.info(`Stretchly ${this.isFirstInstance ? '' : '2'}: forwarding command '${this.command}' to the main instance`)
+          log.info(`Stretchly${this.isFirstInstance ? '' : ' 2'}: forwarding command '${this.command}' to the main instance`)
         }
     }
   }
@@ -184,6 +190,14 @@ class Command {
       default:
         return parseDuration(this.options.duration)
     }
+  }
+
+  waitToMs () {
+    if (!this.options.wait) {
+      return 0
+    }
+
+    return parseDuration(this.options.wait)
   }
 
   checkInMain () {

--- a/app/utils/commands.js
+++ b/app/utils/commands.js
@@ -91,6 +91,10 @@ const allExamples = [{
 {
   cmd: 'stretchly long -T "Stretch up!" -t "Go stretch!"',
   description: 'Start a long break, with the title "Stretch up!" and text "Go stretch!"'
+},
+{
+  cmd: 'stretchly long -w 20m -T "Stretch up!"',
+  description: 'Wait 20 minutes, then start a long break with the title set to "Stretch up!"'
 }]
 
 // Parse cmd line, check if valid and put variables in a dedicated object

--- a/test/commands.js
+++ b/test/commands.js
@@ -116,4 +116,70 @@ describe('commands', () => {
     const cmd = new Command(input, '1.2.3')
     cmd.durationToMs(null).should.be.equal(-1)
   })
+
+  it('parses a number scheduler as the number of minutes to break', () => {
+    const input = ['long', '-w', '60']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(60 * 60 * 1000)
+  })
+
+  it('parses a scheduler argument with hours and minutes', () => {
+    const input = ['long', '-w', '4h39m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(4 * 60 * 60 * 1000 + 39 * 60 * 1000)
+  })
+
+  it('parses a scheduler argument with hours and minutes in the upper case', () => {
+    const input = ['long', '-w', '4H39M']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(4 * 60 * 60 * 1000 + 39 * 60 * 1000)
+  })
+
+  it('parses a scheduler argument with just the minutes', () => {
+    const input = ['long', '-w', '60m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(60 * 60 * 1000)
+  })
+
+  it('parses a scheduler argument with just the hours', () => {
+    const input = ['long', '-w', '184h']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(184 * 60 * 60 * 1000)
+  })
+
+  it('returns -1 if there\'s extra text in the scheduler argument', () => {
+    new Command(['long', '-w', 'foo4h39mbar'], '1.2.3').waitToMs(null).should.be.equal(-1)
+    new Command(['long', '-w', 'foo4h39m'], '1.2.3').waitToMs(null).should.be.equal(-1)
+    new Command(['long', '-w', '4h39mbar'], '1.2.3').waitToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if a number scheduler argument is zero', () => {
+    const input = ['long', '-w', '0']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if the scheduler argument with the hours and minutes evaluates to zero', () => {
+    const input = ['long', '-w', '0h0m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if the scheduler argument with just the minutes evaluates to zero', () => {
+    const input = ['long', '-w', '0m']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(-1)
+  })
+
+  it('returns -1 if the scheduler argument with just the hours evaluates to zero', () => {
+    const input = ['long', '-w', '0h']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(-1)
+  })
+
+  it('should return -1 if the scheduler argument is not in a known format', () => {
+    const input = ['long', '-w', '10i20k']
+    const cmd = new Command(input, '1.2.3')
+    cmd.waitToMs(null).should.be.equal(-1)
+  })
 })


### PR DESCRIPTION
Issue: closes #1091

### Requirements

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [ ] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.
- [ ]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change

In the `Command` class:
- Add new `--wait` option to commands `mini` and `long`.
- Add `waitToMs` method to utilise the existing interval parser (`parseDuration`) from `main.js` when processing CLI options.

`BreaksPlanner`:
- Rename `skipToMicrobreak` to `scheduleMicrobreak` and modify it slightly, adding a new `skipToMicrobreak` function that simply calls `scheduleMicrobreak(100)`
- Ditto for `skipToBreak` and `scheduleBreak`

- Fix a few minor typos and inconsistencies in logged output.