### PR TITLE
Fix/language labels pt br

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - crashing when skipping to break and time to break in tray
+- Portuguese and Brazilian labels in welcome screen
 
 ## [1.10.0] - 2022-2-22
 ### Added

--- a/README.md
+++ b/README.md
@@ -432,6 +432,7 @@ You can help to translate Stretchly on [Weblate](https://hosted.weblate.org/enga
 - Saksham Sharma, [@ssaksham](https://github.com/ssaksham)
 - Jared Wood, [@jwood13](https://github.com/jwood13)
 - Febin Jose, [@JoeNibe](https://github.com/JoeNibe)
+- João Barreiros, [@unstablectrl](https://github.com/unstablectrl)
 
 Also see Github's list of [contributors](https://github.com/hovancik/stretchly/graphs/contributors).
 

--- a/app/welcome.html
+++ b/app/welcome.html
@@ -206,14 +206,14 @@
           <img src="images/flags/flag-portugal.svg" alt="Portugal">
           <input type="radio" value="pt" name="language" id="pt">
           <label for="pt">
-            Brasileiro
+            Português
           </label>
         </div>
         <div>
           <img src="images/flags/flag-brazil.svg" alt="Brazil">
           <input type="radio" value="pt-BR" name="language" id="pt-BR">
           <label for="pt-BR">
-            Português
+            Brasileiro
           </label>
         </div>
         <div>


### PR DESCRIPTION
Issue: closes #1121

### Requirements

- [X]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [X]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [X]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [X]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions.
- [X] `npm run lint` reports no offenses.
- [ ] `npm run test` is error-free.
- [X]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change

Swapped Portuguese with Brazilian labels in the welcome screen

### Verification Process

Install the app and verify that Portuguese and Brazilian labels match their flags

### Other information

For some reason 2 tests didn't pass locally but they are not related to my code since it was failing before my changes (I suspect it might have something to do with timezone)

```
  1) UntilMorning
       Sunrise Settings
         msToSunrise() returns morning time the same day:
     AssertionError: expected 86413000 to be within 3540000..3660000
      at Context.<anonymous> (test/untilMorning.js:72:60)
      at processImmediate (node:internal/timers:464:21)

  2) UntilMorning
       Sunrise Settings
         msToSunrise() returns morning time the next day:
     AssertionError: expected 79213000 to be within 82740000..82860000
      at Context.<anonymous> (test/untilMorning.js:77:60)
      at processImmediate (node:internal/timers:464:21)
```