### PR TITLE
Fix the time displayed in the tray icon

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - error when end break shortcut is not set
+- time in tray shows the correct number (and matches the tooltip value)
 
 ### Changed
 - improved break window loading

--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -270,6 +270,23 @@ class BreaksPlanner extends EventEmitter {
       }
     }
   }
+
+  get timeToNextBreak () {
+    if (this.scheduler.reference === 'startMicrobreak' || this.scheduler.reference === 'startBreak') {
+      return this.scheduler.timeLeft
+    }
+    if (this.scheduler.reference === 'startBreakNotification') {
+      return this.scheduler.timeLeft + (this.settings.get('breakNotification')
+        ? this.settings.get('breakNotificationInterval')
+        : 0)
+    }
+    if (this.scheduler.reference === 'startMicrobreakNotification') {
+      return this.scheduler.timeLeft + (this.settings.get('microbreakNotification')
+        ? this.settings.get('microbreakNotificationInterval')
+        : 0)
+    }
+    return null
+  }
 }
 
 module.exports = BreaksPlanner

--- a/app/main.js
+++ b/app/main.js
@@ -479,7 +479,7 @@ function trayIconPath () {
     darkMode: nativeTheme.shouldUseDarkColors,
     platform: process.platform,
     timeToBreakInTray: settings.get('timeToBreakInTray'),
-    timeToBreak: Utils.minutesRemaining(breakPlanner.scheduler.timeLeft),
+    timeToBreak: Utils.minutesRemaining(breakPlanner.timeToNextBreak),
     reference: breakPlanner.scheduler.reference
   }
   const trayIconFileName = new AppIcon(params).trayIconFileName

--- a/app/utils/appIcon.js
+++ b/app/utils/appIcon.js
@@ -26,7 +26,7 @@ class AppIcon {
     const invertedMonochromeString = this.inverted ? 'Inverted' : ''
     const darkModeString = this.darkMode ? 'Dark' : ''
     const timeToBreakInTrayString = (this.paused || this.reference === 'finishMicrobreak' ||
-      this.reference === 'finishBreak' || !this.timeToBreakInTray)
+      this.reference === 'finishBreak' || !this.timeToBreakInTray || !Number.isInteger(this.timeToBreak))
       ? ''
       : `Number${this.timeToBreak}`
 

--- a/app/utils/statusMessages.js
+++ b/app/utils/statusMessages.js
@@ -7,6 +7,7 @@ class StatusMessages {
     this.doNotDisturb = breakPlanner.dndManager.isOnDnd
     this.appExclusionPause = breakPlanner.appExclusionsManager.isSchedulerCleared
     this.timeLeft = breakPlanner.scheduler.timeLeft
+    this.timeToNextBreak = breakPlanner.timeToNextBreak
     this.isPaused = breakPlanner.isPaused
     this.breakNumber = breakPlanner.breakNumber
     this.settings = settings
@@ -43,38 +44,16 @@ class StatusMessages {
 
     const breakInterval = this.settings.get('breakInterval') + 1
     const breakNumber = this.breakNumber % breakInterval
-    const breakNotificationInterval = this.settings.get('breakNotification')
-      ? this.settings.get('breakNotificationInterval')
-      : 0
-    const microbreakNotificationInterval = this.settings.get('microbreakNotification')
-      ? this.settings.get('microbreakNotificationInterval')
-      : 0
 
-    if (this.reference === 'startBreak') {
+    if (this.reference === 'startBreak' || this.reference === 'startBreakNotification') {
       message += i18next.t('statusMessages.nextLongBreak') + ' ' +
-        Utils.formatTimeIn(this.timeLeft, this.settings.get('language'))
+        Utils.formatTimeIn(this.timeToNextBreak, this.settings.get('language'))
       return message
     }
 
-    if (this.reference === 'startMicrobreak') {
+    if (this.reference === 'startMicrobreak' || this.reference === 'startMicrobreakNotification') {
       message += i18next.t('statusMessages.nextMiniBreak') + ' ' +
-        Utils.formatTimeIn(this.timeLeft, this.settings.get('language'))
-      if (this.settings.get('break')) {
-        message += '\n' + i18next.t('statusMessages.nextLongBreak') + ' ' +
-          i18next.t('statusMessages.afterMiniBreak', { count: breakInterval - breakNumber })
-      }
-      return message
-    }
-
-    if (this.reference === 'startBreakNotification') {
-      message += i18next.t('statusMessages.nextLongBreak') + ' ' +
-        Utils.formatTimeIn(this.timeLeft + breakNotificationInterval, this.settings.get('language'))
-      return message
-    }
-
-    if (this.reference === 'startMicrobreakNotification') {
-      message += i18next.t('statusMessages.nextMiniBreak') + ' ' +
-        Utils.formatTimeIn(this.timeLeft + microbreakNotificationInterval, this.settings.get('language'))
+        Utils.formatTimeIn(this.timeToNextBreak, this.settings.get('language'))
       if (this.settings.get('break')) {
         message += '\n' + i18next.t('statusMessages.nextLongBreak') + ' ' +
           i18next.t('statusMessages.afterMiniBreak', { count: breakInterval - breakNumber })

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -37,9 +37,7 @@ function formatKeyboardShortcut (keyboardShortcut) {
 }
 
 function minutesRemaining (milliseconds) {
-  const seconds = Math.ceil(milliseconds / 1000.0)
-  const minutes = Math.ceil(seconds / 60.0)
-  return minutes
+  return Math.round(milliseconds / 60000.0)
 }
 
 function shouldShowNotificationTitle (platform, systemVersion) {

--- a/test/utils.js
+++ b/test/utils.js
@@ -118,13 +118,16 @@ describe('canSkip and canPostpone', () => {
 
   describe('minutesRemaining', () => {
     it('one minute remaining', () => {
-      minutesRemaining(60000).should.equal(1)
+      minutesRemaining(60 * 1000).should.equal(1)
     })
-    it('less then one minute remaining', () => {
-      minutesRemaining(1).should.equal(1)
+    it('twenty seconds remaining', () => {
+      minutesRemaining(20 * 1000).should.equal(0)
+    })
+    it('forty seconds remaining', () => {
+      minutesRemaining(40 * 1000).should.equal(1)
     })
     it('ten minutes remaining', () => {
-      minutesRemaining(600000).should.equal(10)
+      minutesRemaining(600 * 1000).should.equal(10)
     })
   })
 


### PR DESCRIPTION

<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: closes #1504
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [X]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
  See https://github.com/hovancik/stretchly/pull/1502#discussion_r1824399870
- [X]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [X]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [X]  app version number was not changed.
- [X]  all new code has tests to ensure against regressions.
- [X] `npm run lint` reports no offenses.
- [X] `npm run test` is error-free.
- [X]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
- Take the break notification time into account for the time in the tray
- Move the timeToNextBreak logic into a separate getter that is used everywhere this time is displayed (saves some lines of code)
- Use rounded time for the tray icon (to align with the tooltip), and add an additional unit test for this

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
Ran the software with the changes for some time

### Other information

First discussed [here](https://github.com/hovancik/stretchly/pull/1502#discussion_r1824399870)