### PR TITLE
MacOS Blurred Background

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bengali, Catalan, Greek and Serbian translations
 - it is not possible to close app during break that is in strict mode
 - `logs` command line option to show location of logs
-- advanced option to make window breaks' background blurred
+- advanced option to make break windows' background blurred
 
 ### Fixed
 - error when end break shortcut is not set

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Bengali, Catalan, Greek and Serbian translations
 - it is not possible to close app during break that is in strict mode
 - `logs` command line option to show location of logs
+- advanced option to make window breaks' background blurred
 
 ### Fixed
 - error when end break shortcut is not set

--- a/README.md
+++ b/README.md
@@ -302,7 +302,7 @@ In the preferences file, change `mainColor` to whatever color you like.
 To show the Welcome window again on the next start, change `"isFirstRun"` to `true`.
 
 #### Theme transparency [![Contributor Preferences](https://img.shields.io/badge/Contributor_Preferences-✔-success)](#contributor-preferences)
-To specify how solid the break window should be when Theme transparency is enabled, set the value of `opacity` from `0` to `1` (which is in turn 0 to 100%).
+To specify how solid the break window should be when Theme transparency is enabled, set the value of `opacity` from `0` to `1` (which is in turn 0 to 100%). If you want the break window to have a blurred background, set the value of `blurredBackground` to `true`.
 
 #### Break window size [![Contributor Preferences](https://img.shields.io/badge/Contributor_Preferences-✔-success)](#contributor-preferences)
 To specify the size of the break window, set the value of `breakWindowHeight` and `breakWindowWidth` from `0` to `0.99` (which is in turn 0 to 99% of the size of the screen). Don't set 100% as that's fullscreen.

--- a/app/main.js
+++ b/app/main.js
@@ -668,14 +668,23 @@ function startBreakNotification () {
   updateTray()
 }
 
-function getBreakWindowVibrancyOptions () {
-  if (settings.get('transparentMode') || settings.get('fullscreen') || process.platform !== 'darwin') {
+function getBlurredBackgroundWindowOptions () {
+  if (!settings.get('blurredBackground')) {
     return {}
   }
 
-  return {
-    vibrancy: 'hud',
-    visualEffectState: 'active'
+  switch (process.platform) {
+    case 'darwin':
+      return {
+        vibrancy: 'hud',
+        visualEffectState: 'active'
+      }
+    case 'win32':
+      return {
+        backgroundMaterial: 'acrylic'
+      }
+    default:
+      return {}
   }
 }
 
@@ -715,7 +724,7 @@ function startMicrobreak () {
       show: false,
       backgroundThrottling: false,
       transparent: true,
-      ...getBreakWindowVibrancyOptions(),
+      ...getBlurredBackgroundWindowOptions(),
       backgroundColor: calculateBackgroundColor(settings.get('miniBreakColor')),
       skipTaskbar: !showBreaksAsRegularWindows,
       focusable: showBreaksAsRegularWindows,
@@ -864,7 +873,7 @@ function startBreak () {
       show: false,
       backgroundThrottling: false,
       transparent: true,
-      ...getBreakWindowVibrancyOptions(),
+      ...getBlurredBackgroundWindowOptions(),
       backgroundColor: calculateBackgroundColor(settings.get('mainColor')),
       skipTaskbar: !showBreaksAsRegularWindows,
       focusable: showBreaksAsRegularWindows,

--- a/app/main.js
+++ b/app/main.js
@@ -679,10 +679,6 @@ function getBlurredBackgroundWindowOptions () {
         vibrancy: 'hud',
         visualEffectState: 'active'
       }
-    case 'win32':
-      return {
-        backgroundMaterial: 'acrylic'
-      }
     default:
       return {}
   }

--- a/app/main.js
+++ b/app/main.js
@@ -668,6 +668,17 @@ function startBreakNotification () {
   updateTray()
 }
 
+function getBreakWindowVibrancyOptions () {
+  if (settings.get('transparentMode') || settings.get('fullscreen') || process.platform !== 'darwin') {
+    return {}
+  }
+
+  return {
+    vibrancy: 'hud',
+    visualEffectState: 'active'
+  }
+}
+
 function startMicrobreak () {
   // don't start another break if break running
   if (microbreakWins) {
@@ -704,6 +715,7 @@ function startMicrobreak () {
       show: false,
       backgroundThrottling: false,
       transparent: true,
+      ...getBreakWindowVibrancyOptions(),
       backgroundColor: calculateBackgroundColor(settings.get('miniBreakColor')),
       skipTaskbar: !showBreaksAsRegularWindows,
       focusable: showBreaksAsRegularWindows,
@@ -852,6 +864,7 @@ function startBreak () {
       show: false,
       backgroundThrottling: false,
       transparent: true,
+      ...getBreakWindowVibrancyOptions(),
       backgroundColor: calculateBackgroundColor(settings.get('mainColor')),
       skipTaskbar: !showBreaksAsRegularWindows,
       focusable: showBreaksAsRegularWindows,
@@ -1064,7 +1077,7 @@ function calculateBackgroundColor (color) {
   if (settings.get('transparentMode')) {
     opacityMultiplier = settings.get('opacity')
   }
-  return color + Math.round(opacityMultiplier * 255).toString(16)
+  return color + Math.round(opacityMultiplier * 255).toString(16).padStart(2, '0')
 }
 
 function loadIdeas () {

--- a/app/utils/defaultSettings.js
+++ b/app/utils/defaultSettings.js
@@ -27,6 +27,7 @@ module.exports = {
   mainColor: '#478484',
   miniBreakColor: '#478484',
   transparentMode: false,
+  blurredBackground: false,
   opacity: 0.9,
   audio: 'crystal-glass',
   miniBreakAudio: 'crystal-glass',


### PR DESCRIPTION
Partially solving issue #280 

Adding a simple blurred background on MacOS.
I think it should be the default behavior, but maybe it should be configurable.
It plays nice with the other configurations, such as `opacity`, `transparentMode` and `miniBreakColor`.

I also added support to opacities below 0.0392156863 (=10/255), see the comment in the Review page.

Screenshot (the buttons at the top left side of the window were like that before my change, I assume it's like that when running from source):
<img width="2000" alt="image" src="https://github.com/user-attachments/assets/ffb05f49-1f50-4ad0-af84-6b3f78442e81" />

