### PR TITLE
prevent error with negative time to break in tray icon

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -21,6 +21,7 @@ You are a specialized assistant for developers working on Stretchly, a break-tim
 - Respect the existing project structure
 - Place new functionality in appropriate modules
 - Follow the established patterns for event handling
+- Do not write comments unless absolutely necessary; prefer self-explanatory code
 
 ## Testing Expectations
 - Suggest tests for new functionality

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - do not check for Quiet Hours on Windows (deprecated)
 
 ### Fixed
+- prevent error with negative time to break in tray icon
 - hide close/minimize actions on Break window on macOS
 - issue when not all strings correctly translate after language change
 

--- a/app/utils/appIcon.js
+++ b/app/utils/appIcon.js
@@ -24,7 +24,7 @@ class AppIcon {
     const invertedMonochromeString = this.inverted ? 'Inverted' : ''
     const darkModeString = this.darkMode ? 'Dark' : ''
     const timeToBreakInTrayString = (this.paused || this.reference === 'finishMicrobreak' ||
-      this.reference === 'finishBreak' || !this.timeToBreakInTray || !Number.isInteger(this.timeToBreak))
+      this.reference === 'finishBreak' || !this.timeToBreakInTray || !Number.isInteger(this.timeToBreak) || this.timeToBreak < 0)
       ? ''
       : `Number${this.timeToBreak}`
 

--- a/test/appIcon.js
+++ b/test/appIcon.js
@@ -242,6 +242,21 @@ describe('appIcon', function () {
     appIcon.trayIconFileName.should.equal('trayNumber2.png')
   })
 
+  it('does not add Number when timeToBreak is negative', function () {
+    const params = {
+      paused: false,
+      monochrome: false,
+      inverted: false,
+      darkMode: false,
+      platform: 'linux',
+      timeToBreakInTray: true,
+      timeToBreak: -1,
+      reference: 'startMicrobreak'
+    }
+    const appIcon = new AppIcon(params)
+    appIcon.trayIconFileName.should.equal('tray.png')
+  })
+
   it('trayIconFileName works for light mode on Windows', function () {
     const params = {
       paused: false,


### PR DESCRIPTION
Happens sometimes on Win when PC is locked/unlocked. 