### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/arm-build.yml
+++ b/.github/workflows/arm-build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: write
+
 env:
   USE_SYSTEM_FPM: true
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/flatpak-lint.yml
+++ b/.github/workflows/flatpak-lint.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -5,6 +5,9 @@ on:
     branches:
       - release
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -4,6 +4,8 @@ on: [push, pull_request]
 
 jobs:
   build:
+    permissions:
+      contents: read
     runs-on: ${{ matrix.os }}
 
     strategy:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,10 +2,11 @@ name: Run tests
 
 on: [push, pull_request]
 
+permissions:
+  contents: read
+
 jobs:
   build:
-    permissions:
-      contents: read
     runs-on: ${{ matrix.os }}
 
     strategy:


### PR DESCRIPTION
Potential fix for [https://github.com/hovancik/stretchly/security/code-scanning/5](https://github.com/hovancik/stretchly/security/code-scanning/5)

To fix this issue, add a `permissions` block to the job definition for `build` in `.github/workflows/tests.yml`. Set `contents: read` as a minimal starting point, unless a step demonstrably needs broader permissions. This limits the scope of GITHUB_TOKEN and adheres to least privilege. The best place to insert this is immediately after the job name (`build:`) and before `runs-on:`. No new methods or imports are needed. Only edit the workflow YAML as described.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
