### PR TITLE
Add flatpak portal manager, autostart on flatpaks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - allow to show some HTML in breaks
 - advanced option for manual finish mode for breaks (breaks are only finished after user's interaction)
 - advanced option to set preferred sound to be played at the beginning of breaks
+- Autostart functionality in Flatpaks
 
 ### Fixed
 - hide autostart option for Windows store

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Added
 - new icon styles preference for tray (showing time to break or visual progress to break)
+- Autostart functionality in Flatpaks
 
 ### Fixed
 - snap package not starting on Wayland
@@ -18,7 +19,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - allow to show some HTML in breaks
 - advanced option for manual finish mode for breaks (breaks are only finished after user's interaction)
 - advanced option to set preferred sound to be played at the beginning of breaks
-- Autostart functionality in Flatpaks
 
 ### Fixed
 - hide autostart option for Windows store

--- a/app/main.js
+++ b/app/main.js
@@ -348,6 +348,7 @@ async function initialize (isAppStart = true) {
     } catch (error) {
       log.error('Stretchly: error creating images directory', error)
     }
+  }
   // Initialize portal early for Flatpak so it's ready when user opens preferences
   if (process.platform === 'linux' && insideFlatpak()) {
     autostartManager.flatpakPortalManager.initialize().catch(err => {

--- a/app/main.js
+++ b/app/main.js
@@ -335,8 +335,6 @@ async function initialize (isAppStart = true) {
   }
 
   autostartManager = new AutostartManager({
-    platform: process.platform,
-    windowsStore: insideWindowsStore(),
     app,
     settings
   })

--- a/app/main.js
+++ b/app/main.js
@@ -194,6 +194,10 @@ app.on('before-quit', (event) => {
     event.preventDefault()
   } else {
     globalShortcut.unregisterAll()
+    // Clean up D-Bus connections
+    if (autostartManager) {
+      autostartManager.disconnect()
+    }
     app.quit()
   }
 })
@@ -333,7 +337,8 @@ async function initialize (isAppStart = true) {
   autostartManager = new AutostartManager({
     platform: process.platform,
     windowsStore: insideWindowsStore(),
-    app
+    app,
+    settings
   })
 
   const imagesDir = join(app.getPath('userData'), 'images')
@@ -343,6 +348,11 @@ async function initialize (isAppStart = true) {
     } catch (error) {
       log.error('Stretchly: error creating images directory', error)
     }
+  // Initialize portal early for Flatpak so it's ready when user opens preferences
+  if (process.platform === 'linux' && insideFlatpak()) {
+    autostartManager.flatpakPortalManager.initialize().catch(err => {
+      log.error('Stretchly: Failed to initialize portal manager during startup:', err)
+    })
   }
 
   displayManager = new DisplayManager(settings)

--- a/app/main.js
+++ b/app/main.js
@@ -350,7 +350,7 @@ async function initialize (isAppStart = true) {
     }
   }
   // Initialize portal early for Flatpak so it's ready when user opens preferences
-  if (process.platform === 'linux' && insideFlatpak()) {
+  if (insideFlatpak()) {
     autostartManager.flatpakPortalManager.initialize().catch(err => {
       log.error('Stretchly: Failed to initialize portal manager during startup:', err)
     })

--- a/app/utils/autostartManager.js
+++ b/app/utils/autostartManager.js
@@ -14,7 +14,7 @@ class AutostartManager {
     this.windowsStore = windowsStore
     this.app = app
 
-    this.isFlatpak = this.platform === 'linux' && insideFlatpak()
+    this.isFlatpak = insideFlatpak()
 
     if (this.isFlatpak) {
       this.flatpakPortalManager = new FlatpakPortalManager(settings)

--- a/app/utils/autostartManager.js
+++ b/app/utils/autostartManager.js
@@ -1,30 +1,54 @@
 import log from 'electron-log/main.js'
 import AutoLaunch from 'auto-launch'
+import FlatpakPortalManager from './flatpakPortalManager.js'
+import { insideFlatpak } from './utils.js'
 
 class AutostartManager {
   constructor ({
     platform,
     windowsStore,
-    app
+    app,
+    settings
   }) {
     this.platform = platform
     this.windowsStore = windowsStore
     this.app = app
+    this.settings = settings
+    this.flatpakPortalManager = new FlatpakPortalManager()
   }
 
-  setAutostartEnabled (value) {
-    if (this.platform === 'linux') {
+  async setAutostartEnabled (value) {
+    log.info(`Stretchly: setting autostart to ${value} on ${this.platform}${this.platform === 'win32' && this.windowsStore ? ' (Windows Store)' : ''}${insideFlatpak() && this.platform === 'linux' ? ' (Flatpak)' : ''}`)
+    if (this.platform === 'linux' && insideFlatpak()) {
+      try {
+        // Initialize portal manager first
+        await this.flatpakPortalManager.initialize()
+
+        const result = await this.flatpakPortalManager.setAutostart(value)
+
+        // Only save to settings if portal call succeeded
+        if (result) {
+          this.settings.set('flatpakAutostart', value)
+          log.info(`Stretchly: Saved flatpakAutostart=${value} to settings after successful portal call`)
+        } else {
+          log.warn('Stretchly: Portal call returned false, not saving flatpakAutostart setting')
+        }
+      } catch (error) {
+        log.error('Stretchly: Failed to set autostart via XDG Portal. No fallback available for Flatpak.', error)
+      }
+    } else if (this.platform === 'linux') {
       value ? this._linuxAutoLaunch.enable() : this._linuxAutoLaunch.disable()
     } else if (this.platform === 'win32' && this.windowsStore) {
       value ? this._windowsStoreAutoLaunch.enable() : this._windowsStoreAutoLaunch.disable()
     } else {
       this.app.setLoginItemSettings({ openAtLogin: value })
     }
-    log.info(`Stretchly: setting autostart to ${value} on ${this.platform}${this.platform === 'win32' && this.windowsStore ? ' (Windows Store)' : ''}`)
   }
 
   async autoLaunchStatus () {
-    if (this.platform === 'linux') {
+    if (this.platform === 'linux' && insideFlatpak()) {
+      return this.settings.get('flatpakAutostart', false)
+    } else if (this.platform === 'linux') {
       return await this._linuxAutoLaunch.isEnabled()
     } else if (this.platform === 'win32' && this.windowsStore) {
       return await this._windowsStoreAutoLaunch.isEnabled()
@@ -47,6 +71,12 @@ class AutostartManager {
       isHidden: true
     })
     return stretchlyAutoLaunch
+  }
+
+  disconnect () {
+    if (this.flatpakPortalManager) {
+      this.flatpakPortalManager.disconnect()
+    }
   }
 }
 

--- a/app/utils/autostartManager.js
+++ b/app/utils/autostartManager.js
@@ -20,6 +20,12 @@ class AutostartManager {
       this.flatpakPortalManager = new FlatpakPortalManager(settings)
     } else if (this.platform === 'linux') {
       this.nativeAutoLauncher = new AutoLaunch({ name: 'stretchly' })
+    } else if (this.platform === 'win32' && this.windowsStore) {
+      this.windowsStoreAutoLauncher = new AutoLaunch({
+        name: 'Stretchly',
+        path: '33881JanHovancik.stretchly_24fg4m0zq65je!Stretchly',
+        isHidden: true
+      })
     }
   }
 
@@ -31,7 +37,7 @@ class AutostartManager {
     } else if (this.platform === 'linux') {
       await (value ? this.nativeAutoLauncher.enable() : this.nativeAutoLauncher.disable())
     } else if (this.platform === 'win32' && this.windowsStore) {
-      await (value ? this._windowsStoreAutoLaunch.enable() : this._windowsStoreAutoLaunch.disable())
+      await (value ? this.windowsStoreAutoLauncher.enable() : this.windowsStoreAutoLauncher.disable())
     } else {
       this.app.setLoginItemSettings({ openAtLogin: value })
     }
@@ -43,19 +49,10 @@ class AutostartManager {
     } else if (this.platform === 'linux') {
       return await this.nativeAutoLauncher.isEnabled()
     } else if (this.platform === 'win32' && this.windowsStore) {
-      return await this._windowsStoreAutoLaunch.isEnabled()
+      return await this.windowsStoreAutoLauncher.isEnabled()
     } else {
-      return await this.app.getLoginItemSettings().openAtLogin
+      return this.app.getLoginItemSettings().openAtLogin
     }
-  }
-
-  get _windowsStoreAutoLaunch () {
-    const stretchlyAutoLaunch = new AutoLaunch({
-      name: 'Stretchly',
-      path: '33881JanHovancik.stretchly_24fg4m0zq65je!Stretchly',
-      isHidden: true
-    })
-    return stretchlyAutoLaunch
   }
 
   disconnect () {

--- a/app/utils/autostartManager.js
+++ b/app/utils/autostartManager.js
@@ -13,50 +13,23 @@ class AutostartManager {
     this.platform = platform
     this.windowsStore = windowsStore
     this.app = app
-    this.settings = settings
-    this.flatpakPortalManager = new FlatpakPortalManager()
 
-    // Decide the Linux autostart strategy once during construction
-    if (this.platform === 'linux') {
-      if (insideFlatpak()) {
-        this._linuxAutoLaunch = this._createFlatpakAutostarter()
-      } else {
-        this._linuxAutoLaunch = new AutoLaunch({ name: 'stretchly' })
-      }
-    }
-  }
+    this.isFlatpak = this.platform === 'linux' && insideFlatpak()
 
-  _createFlatpakAutostarter () {
-    return {
-      enable: async () => {
-        try {
-          await this.flatpakPortalManager.initialize()
-          await this.flatpakPortalManager.setAutostart(true)
-          this.settings.set('flatpakAutostart', true)
-        } catch (error) {
-          log.error('Stretchly: Failed to set autostart (enable) via XDG Portal', error)
-        }
-      },
-      disable: async () => {
-        try {
-          await this.flatpakPortalManager.initialize()
-          await this.flatpakPortalManager.setAutostart(false)
-          this.settings.set('flatpakAutostart', false)
-        } catch (error) {
-          log.error('Stretchly: Failed to set autostart (disable) via XDG Portal', error)
-        }
-      },
-      isEnabled: async () => {
-        // XDG portals don't provide a reliable query method, so we read from our cache
-        return Promise.resolve(this.settings.get('flatpakAutostart', false))
-      }
+    if (this.isFlatpak) {
+      this.flatpakPortalManager = new FlatpakPortalManager(settings)
+    } else if (this.platform === 'linux') {
+      this.nativeAutoLauncher = new AutoLaunch({ name: 'stretchly' })
     }
   }
 
   async setAutostartEnabled (value) {
-    log.info(`Stretchly: setting autostart to ${value} on ${this.platform}${this.platform === 'win32' && this.windowsStore ? ' (Windows Store)' : ''}${insideFlatpak() && this.platform === 'linux' ? ' (Flatpak)' : ''}`)
-    if (this.platform === 'linux') {
-      await (value ? this._linuxAutoLaunch.enable() : this._linuxAutoLaunch.disable())
+    log.info(`Stretchly: setting autostart to ${value} on ${this.platform}${this.platform === 'win32' && this.windowsStore ? ' (Windows Store)' : ''}${this.isFlatpak ? ' (Flatpak)' : ''}`)
+
+    if (this.isFlatpak) {
+      await (value ? this.flatpakPortalManager.enableAutostart() : this.flatpakPortalManager.disableAutostart())
+    } else if (this.platform === 'linux') {
+      await (value ? this.nativeAutoLauncher.enable() : this.nativeAutoLauncher.disable())
     } else if (this.platform === 'win32' && this.windowsStore) {
       await (value ? this._windowsStoreAutoLaunch.enable() : this._windowsStoreAutoLaunch.disable())
     } else {
@@ -65,8 +38,10 @@ class AutostartManager {
   }
 
   async autoLaunchStatus () {
-    if (this.platform === 'linux') {
-      return await this._linuxAutoLaunch.isEnabled()
+    if (this.isFlatpak) {
+      return await this.flatpakPortalManager.isAutostartEnabled()
+    } else if (this.platform === 'linux') {
+      return await this.nativeAutoLauncher.isEnabled()
     } else if (this.platform === 'win32' && this.windowsStore) {
       return await this._windowsStoreAutoLaunch.isEnabled()
     } else {

--- a/app/utils/autostartManager.js
+++ b/app/utils/autostartManager.js
@@ -1,26 +1,23 @@
 import log from 'electron-log/main.js'
 import AutoLaunch from 'auto-launch'
 import FlatpakPortalManager from './flatpakPortalManager.js'
-import { insideFlatpak } from './utils.js'
+import { insideFlatpak, insideWindowsStore } from './utils.js'
 
 class AutostartManager {
   constructor ({
-    platform,
-    windowsStore,
     app,
     settings
   }) {
-    this.platform = platform
-    this.windowsStore = windowsStore
     this.app = app
 
     this.isFlatpak = insideFlatpak()
+    this.isWindowsStore = insideWindowsStore()
 
     if (this.isFlatpak) {
       this.flatpakPortalManager = new FlatpakPortalManager(settings)
-    } else if (this.platform === 'linux') {
+    } else if (process.platform === 'linux') {
       this.nativeAutoLauncher = new AutoLaunch({ name: 'stretchly' })
-    } else if (this.platform === 'win32' && this.windowsStore) {
+    } else if (this.isWindowsStore) {
       this.windowsStoreAutoLauncher = new AutoLaunch({
         name: 'Stretchly',
         path: '33881JanHovancik.stretchly_24fg4m0zq65je!Stretchly',
@@ -30,13 +27,13 @@ class AutostartManager {
   }
 
   async setAutostartEnabled (value) {
-    log.info(`Stretchly: setting autostart to ${value} on ${this.platform}${this.platform === 'win32' && this.windowsStore ? ' (Windows Store)' : ''}${this.isFlatpak ? ' (Flatpak)' : ''}`)
+    log.info(`Stretchly: setting autostart to ${value} on ${process.platform}${this.isWindowsStore ? ' (Windows Store)' : ''}${this.isFlatpak ? ' (Flatpak)' : ''}`)
 
     if (this.isFlatpak) {
       await (value ? this.flatpakPortalManager.enableAutostart() : this.flatpakPortalManager.disableAutostart())
-    } else if (this.platform === 'linux') {
+    } else if (process.platform === 'linux') {
       await (value ? this.nativeAutoLauncher.enable() : this.nativeAutoLauncher.disable())
-    } else if (this.platform === 'win32' && this.windowsStore) {
+    } else if (this.isWindowsStore) {
       await (value ? this.windowsStoreAutoLauncher.enable() : this.windowsStoreAutoLauncher.disable())
     } else {
       this.app.setLoginItemSettings({ openAtLogin: value })
@@ -46,9 +43,9 @@ class AutostartManager {
   async autoLaunchStatus () {
     if (this.isFlatpak) {
       return await this.flatpakPortalManager.isAutostartEnabled()
-    } else if (this.platform === 'linux') {
+    } else if (process.platform === 'linux') {
       return await this.nativeAutoLauncher.isEnabled()
-    } else if (this.platform === 'win32' && this.windowsStore) {
+    } else if (this.isWindowsStore) {
       return await this.windowsStoreAutoLauncher.isEnabled()
     } else {
       return this.app.getLoginItemSettings().openAtLogin

--- a/app/utils/autostartManager.js
+++ b/app/utils/autostartManager.js
@@ -15,53 +15,63 @@ class AutostartManager {
     this.app = app
     this.settings = settings
     this.flatpakPortalManager = new FlatpakPortalManager()
+
+    // Decide the Linux autostart strategy once during construction
+    if (this.platform === 'linux') {
+      if (insideFlatpak()) {
+        this._linuxAutoLaunch = this._createFlatpakAutostarter()
+      } else {
+        this._linuxAutoLaunch = new AutoLaunch({ name: 'stretchly' })
+      }
+    }
+  }
+
+  _createFlatpakAutostarter () {
+    return {
+      enable: async () => {
+        try {
+          await this.flatpakPortalManager.initialize()
+          await this.flatpakPortalManager.setAutostart(true)
+          this.settings.set('flatpakAutostart', true)
+        } catch (error) {
+          log.error('Stretchly: Failed to set autostart (enable) via XDG Portal', error)
+        }
+      },
+      disable: async () => {
+        try {
+          await this.flatpakPortalManager.initialize()
+          await this.flatpakPortalManager.setAutostart(false)
+          this.settings.set('flatpakAutostart', false)
+        } catch (error) {
+          log.error('Stretchly: Failed to set autostart (disable) via XDG Portal', error)
+        }
+      },
+      isEnabled: async () => {
+        // XDG portals don't provide a reliable query method, so we read from our cache
+        return Promise.resolve(this.settings.get('flatpakAutostart', false))
+      }
+    }
   }
 
   async setAutostartEnabled (value) {
     log.info(`Stretchly: setting autostart to ${value} on ${this.platform}${this.platform === 'win32' && this.windowsStore ? ' (Windows Store)' : ''}${insideFlatpak() && this.platform === 'linux' ? ' (Flatpak)' : ''}`)
-    if (this.platform === 'linux' && insideFlatpak()) {
-      try {
-        // Initialize portal manager first
-        await this.flatpakPortalManager.initialize()
-
-        const result = await this.flatpakPortalManager.setAutostart(value)
-
-        // Only save to settings if portal call succeeded
-        if (result) {
-          this.settings.set('flatpakAutostart', value)
-          log.info(`Stretchly: Saved flatpakAutostart=${value} to settings after successful portal call`)
-        } else {
-          log.warn('Stretchly: Portal call returned false, not saving flatpakAutostart setting')
-        }
-      } catch (error) {
-        log.error('Stretchly: Failed to set autostart via XDG Portal. No fallback available for Flatpak.', error)
-      }
-    } else if (this.platform === 'linux') {
-      value ? this._linuxAutoLaunch.enable() : this._linuxAutoLaunch.disable()
+    if (this.platform === 'linux') {
+      await (value ? this._linuxAutoLaunch.enable() : this._linuxAutoLaunch.disable())
     } else if (this.platform === 'win32' && this.windowsStore) {
-      value ? this._windowsStoreAutoLaunch.enable() : this._windowsStoreAutoLaunch.disable()
+      await (value ? this._windowsStoreAutoLaunch.enable() : this._windowsStoreAutoLaunch.disable())
     } else {
       this.app.setLoginItemSettings({ openAtLogin: value })
     }
   }
 
   async autoLaunchStatus () {
-    if (this.platform === 'linux' && insideFlatpak()) {
-      return this.settings.get('flatpakAutostart', false)
-    } else if (this.platform === 'linux') {
+    if (this.platform === 'linux') {
       return await this._linuxAutoLaunch.isEnabled()
     } else if (this.platform === 'win32' && this.windowsStore) {
       return await this._windowsStoreAutoLaunch.isEnabled()
     } else {
       return await this.app.getLoginItemSettings().openAtLogin
     }
-  }
-
-  get _linuxAutoLaunch () {
-    const stretchlyAutoLaunch = new AutoLaunch({
-      name: 'stretchly'
-    })
-    return stretchlyAutoLaunch
   }
 
   get _windowsStoreAutoLaunch () {

--- a/app/utils/defaultSettings.js
+++ b/app/utils/defaultSettings.js
@@ -80,5 +80,6 @@ export default {
   hidePreferencesFileLocation: false,
   hideStrictModePreferences: false,
   miniBreakManualFinish: false,
-  longBreakManualFinish: false
+  longBreakManualFinish: false,
+  flatpakAutostart: false
 }

--- a/app/utils/flatpakPortalManager.js
+++ b/app/utils/flatpakPortalManager.js
@@ -159,8 +159,10 @@ class FlatpakPortalManager {
 
   async disableAutostart () {
     try {
-      await this.setAutostart(false)
-      this.settings.set('flatpakAutostart', false)
+      const success = await this.setAutostart(false)
+      if (success) {
+        this.settings.set('flatpakAutostart', false)
+      }
     } catch (error) {
       log.error('Stretchly: Failed to set autostart (disable) via XDG Portal', error)
     }

--- a/app/utils/flatpakPortalManager.js
+++ b/app/utils/flatpakPortalManager.js
@@ -9,6 +9,7 @@ class FlatpakPortalManager {
     this.bus = null
     this.portal = null
     this.initialized = false
+    this.portalRequestTimeoutMs = 30000
   }
 
   async initialize () {
@@ -70,80 +71,87 @@ class FlatpakPortalManager {
         return true
       }
 
-      // When enabling autostart, we must wait for the Response signal
-      return new Promise((resolve) => {
-        const timeoutMs = 30000
-        let timeoutId = null
-        let messageListener = null
+      // When enabling autostart, we must wait for the Response signal.
+      // We start listening BEFORE calling the method to avoid race conditions.
+      const responsePromise = this._waitForBusResponse(handleToken, enabled)
 
-        const cleanup = () => {
-          if (timeoutId) {
-            clearTimeout(timeoutId)
-            timeoutId = null
-          }
-          if (messageListener && this.bus) {
-            this.bus.off('message', messageListener)
-            messageListener = null
-          }
-        }
+      await background.RequestBackground('', options)
+        .then(requestPath => {
+          log.info(`Stretchly: RequestBackground called, request path: ${requestPath}`)
+        })
 
-        messageListener = (msg) => {
-          if (msg.interface === 'org.freedesktop.portal.Request' &&
-              msg.member === 'Response' &&
-              msg.path.includes(handleToken)) {
-            const [response, results] = msg.body
-
-            cleanup()
-
-            log.info(`Stretchly: Portal Response signal received - response: ${response}, results:`, results)
-
-            // Response codes: 0 = success, 1 = user cancelled, 2 = other error
-            if (response === 0) {
-              const autostartGranted = results && results.autostart && results.autostart.value === enabled
-              if (autostartGranted) {
-                log.info('Stretchly: Autostart enabled via XDG Portal')
-              } else {
-                log.warn('Stretchly: Autostart status did not match request', results)
-              }
-              resolve(autostartGranted)
-            } else if (response === 1) {
-              log.warn('Stretchly: User cancelled the portal request')
-              resolve(false)
-            } else {
-              log.error(`Stretchly: Portal request failed with response code: ${response}`)
-              resolve(false)
-            }
-          }
-        }
-
-        timeoutId = setTimeout(() => {
-          cleanup()
-          log.error('Stretchly: Portal request timeout after 30 seconds')
-          resolve(false)
-        }, timeoutMs)
-
-        this.bus.on('message', messageListener)
-
-        background.RequestBackground('', options)
-          .then(requestPath => {
-            log.info(`Stretchly: RequestBackground called, request path: ${requestPath}`)
-          })
-          .catch(err => {
-            cleanup()
-            log.error('Stretchly: Failed to call RequestBackground:', err)
-            resolve(false)
-          })
-      })
+      return await responsePromise
     } catch (error) {
       log.error(`Stretchly: Failed to set autostart=${enabled} via XDG Portal:`, error)
       return false
     }
   }
 
+  /**
+   * Waits for the Portal Request Response signal.
+   * @private
+   */
+  _waitForBusResponse (handleToken, expectingEnabled) {
+    return new Promise((resolve) => {
+      let timeoutId = null
+      let messageListener = null
+
+      const cleanup = () => {
+        if (timeoutId) {
+          clearTimeout(timeoutId)
+          timeoutId = null
+        }
+        if (messageListener && this.bus) {
+          this.bus.off('message', messageListener)
+          messageListener = null
+        }
+      }
+
+      messageListener = (msg) => {
+        if (msg.interface === 'org.freedesktop.portal.Request' &&
+            msg.member === 'Response' &&
+            msg.path.endsWith(handleToken)) {
+          const [response, results] = msg.body
+
+          cleanup()
+
+          log.info(`Stretchly: Portal Response signal received - response: ${response}, results:`, results)
+
+          // Response codes: 0 = success, 1 = user cancelled, 2 = other error
+          if (response === 0) {
+            const autostartGranted = results && results.autostart && results.autostart.value === expectingEnabled
+            if (autostartGranted) {
+              log.info('Stretchly: Autostart enabled via XDG Portal')
+            } else {
+              log.warn('Stretchly: Autostart status did not match request', results)
+            }
+            resolve(autostartGranted)
+          } else if (response === 1) {
+            log.warn('Stretchly: User cancelled the portal request')
+            resolve(false)
+          } else {
+            log.error(`Stretchly: Portal request failed with response code: ${response}`)
+            resolve(false)
+          }
+        }
+      }
+
+      timeoutId = setTimeout(() => {
+        cleanup()
+        log.error(`Stretchly: Portal request timeout after ${this.portalRequestTimeoutMs / 1000} seconds`)
+        resolve(false)
+      }, this.portalRequestTimeoutMs)
+
+      this.bus.on('message', messageListener)
+    })
+  }
+
   async enableAutostart () {
     try {
-      await this.setAutostart(true)
-      this.settings.set('flatpakAutostart', true)
+      const success = await this.setAutostart(true)
+      if (success) {
+        this.settings.set('flatpakAutostart', true)
+      }
     } catch (error) {
       log.error('Stretchly: Failed to set autostart (enable) via XDG Portal', error)
     }

--- a/app/utils/flatpakPortalManager.js
+++ b/app/utils/flatpakPortalManager.js
@@ -18,7 +18,7 @@ class FlatpakPortalManager {
     if (this.bus) {
       try {
         this.bus.disconnect()
-      } catch (err) {
+      } catch {
         // Ignore disconnect errors
       }
       this.bus = null
@@ -66,19 +66,22 @@ class FlatpakPortalManager {
       // When disabling autostart, the portal doesn't create a persistent request object.
       // No Response signal is emitted, so we can return immediately.
       if (!enabled) {
-        await background.RequestBackground('', options)
-        log.info('Stretchly: Autostart disabled via XDG Portal')
-        return true
+        try {
+          await background.RequestBackground('', options)
+          log.info('Stretchly: Autostart disabled via XDG Portal')
+          return true
+        } catch (error) {
+          log.error('Stretchly: Failed to disable autostart via XDG Portal:', error)
+          return false
+        }
       }
 
       // When enabling autostart, we must wait for the Response signal.
       // We start listening BEFORE calling the method to avoid race conditions.
       const responsePromise = this._waitForBusResponse(handleToken, enabled)
 
-      await background.RequestBackground('', options)
-        .then(requestPath => {
-          log.info(`Stretchly: RequestBackground called, request path: ${requestPath}`)
-        })
+      const requestPath = await background.RequestBackground('', options)
+      log.info(`Stretchly: RequestBackground called, request path: ${requestPath}`)
 
       return await responsePromise
     } catch (error) {
@@ -152,8 +155,10 @@ class FlatpakPortalManager {
       if (success) {
         this.settings.set('flatpakAutostart', true)
       }
+      return success
     } catch (error) {
       log.error('Stretchly: Failed to set autostart (enable) via XDG Portal', error)
+      return false
     }
   }
 
@@ -163,8 +168,10 @@ class FlatpakPortalManager {
       if (success) {
         this.settings.set('flatpakAutostart', false)
       }
+      return success
     } catch (error) {
       log.error('Stretchly: Failed to set autostart (disable) via XDG Portal', error)
+      return false
     }
   }
 

--- a/app/utils/flatpakPortalManager.js
+++ b/app/utils/flatpakPortalManager.js
@@ -13,12 +13,11 @@ class FlatpakPortalManager {
   async initialize () {
     if (this.initialized) return
 
-    // Clean up any stale connection first
     if (this.bus) {
       try {
         this.bus.disconnect()
       } catch (err) {
-        // Ignore errors disconnecting stale connection
+        // Ignore disconnect errors
       }
       this.bus = null
       this.portal = null
@@ -45,13 +44,10 @@ class FlatpakPortalManager {
    * @returns {Promise<boolean>} - True if the autostart status was successfully set.
    */
   async setAutostart (enabled) {
-    // Ensure initialized (safe to call multiple times)
     await this.initialize()
 
     try {
       const background = this.portal.getInterface('org.freedesktop.portal.Background')
-
-      // Create a unique handle token for this request
       const handleToken = `stretchly_autostart_${Date.now()}_${Math.random().toString(36).substring(7)}`
 
       const options = {
@@ -61,19 +57,19 @@ class FlatpakPortalManager {
         'dbus-activatable': new Variant('b', false)
       }
 
-      // When DISABLING, the portal doesn't create a persistent request object
-      // It's a fire-and-forget operation - no Response signal to wait for
+      // When disabling autostart, the portal doesn't create a persistent request object.
+      // No Response signal is emitted, so we can return immediately.
       if (!enabled) {
         await background.RequestBackground('', options)
-        log.info('Stretchly: Autostart disabled via XDG Portal (no response expected).')
+        log.info('Stretchly: Autostart disabled via XDG Portal')
         return true
       }
 
-      // When ENABLING, we must wait for the Response signal
+      // When enabling autostart, we must wait for the Response signal
       return new Promise((resolve) => {
-        const timeoutMs = 30000 // 30 second timeout
+        const timeoutMs = 30000
         let timeoutId = null
-        let messageListener = null // Store the listener function here
+        let messageListener = null
 
         const cleanup = () => {
           if (timeoutId) {
@@ -81,59 +77,54 @@ class FlatpakPortalManager {
             timeoutId = null
           }
           if (messageListener && this.bus) {
-            // The actual listener removal
             this.bus.off('message', messageListener)
             messageListener = null
           }
         }
 
-        // Define the listener function
         messageListener = (msg) => {
-          // Check if this message is the one we're waiting for
           if (msg.interface === 'org.freedesktop.portal.Request' &&
               msg.member === 'Response' &&
               msg.path.includes(handleToken)) {
             const [response, results] = msg.body
 
-            cleanup() // Clean up immediately (removes listener + timeout)
+            cleanup()
 
             log.info(`Stretchly: Portal Response signal received - response: ${response}, results:`, results)
 
-            if (response === 0) { // Success
+            // Response codes: 0 = success, 1 = user cancelled, 2 = other error
+            if (response === 0) {
               const autostartGranted = results && results.autostart && results.autostart.value === enabled
               if (autostartGranted) {
-                log.info('Stretchly: Autostart successfully enabled via XDG Portal.')
+                log.info('Stretchly: Autostart enabled via XDG Portal')
               } else {
-                log.warn('Stretchly: Autostart status did not match request. Results:', results)
+                log.warn('Stretchly: Autostart status did not match request', results)
               }
               resolve(autostartGranted)
-            } else if (response === 1) { // User cancelled
-              log.warn('Stretchly: User cancelled the portal request.')
+            } else if (response === 1) {
+              log.warn('Stretchly: User cancelled the portal request')
               resolve(false)
-            } else { // Other error
+            } else {
               log.error(`Stretchly: Portal request failed with response code: ${response}`)
               resolve(false)
             }
           }
         }
 
-        // Set the timeout
         timeoutId = setTimeout(() => {
-          cleanup() // This will now remove the listener
+          cleanup()
           log.error('Stretchly: Portal request timeout after 30 seconds')
           resolve(false)
         }, timeoutMs)
 
-        // Listen for Response signals
-        this.bus.on('message', messageListener) // Register the named listener
+        this.bus.on('message', messageListener)
 
-        // NOW make the request
         background.RequestBackground('', options)
           .then(requestPath => {
-            log.info(`Stretchly: RequestBackground called for autostart=true, request path: ${requestPath}`)
+            log.info(`Stretchly: RequestBackground called, request path: ${requestPath}`)
           })
           .catch(err => {
-            cleanup() // This will now remove the listener
+            cleanup()
             log.error('Stretchly: Failed to call RequestBackground:', err)
             resolve(false)
           })

--- a/app/utils/flatpakPortalManager.js
+++ b/app/utils/flatpakPortalManager.js
@@ -4,7 +4,8 @@ import log from 'electron-log/main.js'
 const { Variant } = dbus
 
 class FlatpakPortalManager {
-  constructor () {
+  constructor (settings) {
+    this.settings = settings
     this.bus = null
     this.portal = null
     this.initialized = false
@@ -34,7 +35,6 @@ class FlatpakPortalManager {
     } catch (error) {
       log.error('Stretchly: Failed to initialize XDG Background Portal:', error)
       this.initialized = false
-      throw error
     }
   }
 
@@ -45,6 +45,11 @@ class FlatpakPortalManager {
    */
   async setAutostart (enabled) {
     await this.initialize()
+
+    if (!this.initialized) {
+      log.error('Stretchly: Cannot set autostart - portal not initialized')
+      return false
+    }
 
     try {
       const background = this.portal.getInterface('org.freedesktop.portal.Background')
@@ -131,8 +136,31 @@ class FlatpakPortalManager {
       })
     } catch (error) {
       log.error(`Stretchly: Failed to set autostart=${enabled} via XDG Portal:`, error)
-      throw error
+      return false
     }
+  }
+
+  async enableAutostart () {
+    try {
+      await this.setAutostart(true)
+      this.settings.set('flatpakAutostart', true)
+    } catch (error) {
+      log.error('Stretchly: Failed to set autostart (enable) via XDG Portal', error)
+    }
+  }
+
+  async disableAutostart () {
+    try {
+      await this.setAutostart(false)
+      this.settings.set('flatpakAutostart', false)
+    } catch (error) {
+      log.error('Stretchly: Failed to set autostart (disable) via XDG Portal', error)
+    }
+  }
+
+  async isAutostartEnabled () {
+    // XDG portals don't provide a reliable query method, so we read from our cache
+    return this.settings.get('flatpakAutostart')
   }
 
   disconnect () {

--- a/app/utils/flatpakPortalManager.js
+++ b/app/utils/flatpakPortalManager.js
@@ -1,0 +1,158 @@
+import dbus from '@particle/dbus-next'
+import log from 'electron-log/main.js'
+
+const { Variant } = dbus
+
+class FlatpakPortalManager {
+  constructor () {
+    this.bus = null
+    this.portal = null
+    this.initialized = false
+  }
+
+  async initialize () {
+    if (this.initialized) return
+
+    // Clean up any stale connection first
+    if (this.bus) {
+      try {
+        this.bus.disconnect()
+      } catch (err) {
+        // Ignore errors disconnecting stale connection
+      }
+      this.bus = null
+      this.portal = null
+    }
+
+    try {
+      this.bus = dbus.sessionBus()
+      this.portal = await this.bus.getProxyObject(
+        'org.freedesktop.portal.Desktop',
+        '/org/freedesktop/portal/desktop'
+      )
+      this.initialized = true
+      log.info('Stretchly: XDG Background Portal initialized successfully')
+    } catch (error) {
+      log.error('Stretchly: Failed to initialize XDG Background Portal:', error)
+      this.initialized = false
+      throw error
+    }
+  }
+
+  /**
+   * Sets the autostart status for the application using the XDG Background Portal.
+   * @param {boolean} enabled - True to enable autostart, false to disable.
+   * @returns {Promise<boolean>} - True if the autostart status was successfully set.
+   */
+  async setAutostart (enabled) {
+    // Ensure initialized (safe to call multiple times)
+    await this.initialize()
+
+    try {
+      const background = this.portal.getInterface('org.freedesktop.portal.Background')
+
+      // Create a unique handle token for this request
+      const handleToken = `stretchly_autostart_${Date.now()}_${Math.random().toString(36).substring(7)}`
+
+      const options = {
+        handle_token: new Variant('s', handleToken),
+        reason: new Variant('s', 'Stretchly needs to run in the background to remind you to take breaks'),
+        autostart: new Variant('b', enabled),
+        'dbus-activatable': new Variant('b', false)
+      }
+
+      // When DISABLING, the portal doesn't create a persistent request object
+      // It's a fire-and-forget operation - no Response signal to wait for
+      if (!enabled) {
+        await background.RequestBackground('', options)
+        log.info('Stretchly: Autostart disabled via XDG Portal (no response expected).')
+        return true
+      }
+
+      // When ENABLING, we must wait for the Response signal
+      return new Promise((resolve) => {
+        const timeoutMs = 30000 // 30 second timeout
+        let timeoutId = null
+        let messageListener = null // Store the listener function here
+
+        const cleanup = () => {
+          if (timeoutId) {
+            clearTimeout(timeoutId)
+            timeoutId = null
+          }
+          if (messageListener && this.bus) {
+            // The actual listener removal
+            this.bus.off('message', messageListener)
+            messageListener = null
+          }
+        }
+
+        // Define the listener function
+        messageListener = (msg) => {
+          // Check if this message is the one we're waiting for
+          if (msg.interface === 'org.freedesktop.portal.Request' &&
+              msg.member === 'Response' &&
+              msg.path.includes(handleToken)) {
+            const [response, results] = msg.body
+
+            cleanup() // Clean up immediately (removes listener + timeout)
+
+            log.info(`Stretchly: Portal Response signal received - response: ${response}, results:`, results)
+
+            if (response === 0) { // Success
+              const autostartGranted = results && results.autostart && results.autostart.value === enabled
+              if (autostartGranted) {
+                log.info('Stretchly: Autostart successfully enabled via XDG Portal.')
+              } else {
+                log.warn('Stretchly: Autostart status did not match request. Results:', results)
+              }
+              resolve(autostartGranted)
+            } else if (response === 1) { // User cancelled
+              log.warn('Stretchly: User cancelled the portal request.')
+              resolve(false)
+            } else { // Other error
+              log.error(`Stretchly: Portal request failed with response code: ${response}`)
+              resolve(false)
+            }
+          }
+        }
+
+        // Set the timeout
+        timeoutId = setTimeout(() => {
+          cleanup() // This will now remove the listener
+          log.error('Stretchly: Portal request timeout after 30 seconds')
+          resolve(false)
+        }, timeoutMs)
+
+        // Listen for Response signals
+        this.bus.on('message', messageListener) // Register the named listener
+
+        // NOW make the request
+        background.RequestBackground('', options)
+          .then(requestPath => {
+            log.info(`Stretchly: RequestBackground called for autostart=true, request path: ${requestPath}`)
+          })
+          .catch(err => {
+            cleanup() // This will now remove the listener
+            log.error('Stretchly: Failed to call RequestBackground:', err)
+            resolve(false)
+          })
+      })
+    } catch (error) {
+      log.error(`Stretchly: Failed to set autostart=${enabled} via XDG Portal:`, error)
+      throw error
+    }
+  }
+
+  disconnect () {
+    if (this.bus) {
+      this.bus.disconnect()
+      this.bus = null
+      this.portal = null
+      this.initialized = false
+      log.info('Stretchly: XDG Background Portal disconnected')
+    }
+  }
+}
+
+export default FlatpakPortalManager

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -76,8 +76,7 @@ function shouldShowNotificationTitle (platform, systemVersion, semver) {
 }
 
 function insideFlatpak () {
-  const flatpakInfoPath = '/.flatpak-info'
-  return fs.existsSync(flatpakInfoPath)
+  return process.platform === 'linux' && fs.existsSync('/.flatpak-info')
 }
 
 function insideWindowsStore () {
@@ -85,7 +84,7 @@ function insideWindowsStore () {
 }
 
 function insideSnap () {
-  return !!process.env.SNAP
+  return process.platform === 'linux' && !!process.env.SNAP
 }
 
 export {


### PR DESCRIPTION
<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: closes #1652 #1517 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.
- [x]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->
1. Add Flatpak detection to AutoStart manager
2. Changed AutoStart manager to async because d-bus methods are async
3. Follow docs at [doc-org.freedesktop.portal.Background](https://flatpak.github.io/xdg-desktop-portal/docs/doc-org.freedesktop.portal.Background.html) for `options` field in `setAutostart`
4. Get background status by checking for `~/.config/autostart/net.hovancik.Stretchly.desktop`. Requires a PR to the flatpak repo. https://github.com/flathub/net.hovancik.Stretchly/pull/23

### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->
I was on Fedora 42.
I build the flatpak and ran it as described in [net.hovancik.Stretchly](https://github.com/flathub/net.hovancik.Stretchly)

I checked the checkbox to "run at startup", and saw that a file was made in autostart, as expected.
```
cat ~/.config/autostart/net.hovancik.Stretchly.desktop    
[Desktop Entry]  
Type=Application  
Name=net.hovancik.Stretchly  
X-XDP-Autostart=net.hovancik.Stretchly  
Exec=flatpak run net.hovancik.Stretchly  
X-Flatpak=net.hovancik.Stretchly
```

When I unchecked the checkbox, the file no longer existed. Perfect.
When I checked the checkbox and rebooted my computer, stretchly opened on startup.

I fixed the error I spoke of previously

Log:
```
12:07:48.985 › Stretchly: setting autostart to true on linux (Flatpak)
12:07:48.991 › Stretchly: RequestBackground called for autostart=true, request path: /org/freedesktop/portal/desktop/request/1_266/stretchly_autostart_1760198868989_s3uwx
12:07:48.991 › Stretchly: Portal Response signal received - response: 0, results: {
  background: { signature: 'b', value: true },
  autostart: { signature: 'b', value: true }
}
12:07:48.993 › Stretchly: Autostart successfully enabled via XDG Portal.
12:07:49.951 › Stretchly: setting autostart to false on linux (Flatpak)
12:07:49.958 › Stretchly: Autostart disabled via XDG Portal (no response expected).
12:07:50.582 › Stretchly: setting autostart to true on linux (Flatpak)
12:07:50.590 › Stretchly: RequestBackground called for autostart=true, request path: /org/freedesktop/portal/desktop/request/1_266/stretchly_autostart_1760198870587_qae8dg
12:07:50.590 › Stretchly: Portal Response signal received - response: 0, results: {
  background: { signature: 'b', value: true },
  autostart: { signature: 'b', value: true }
}
12:07:50.591 › Stretchly: Autostart successfully enabled via XDG Portal.
```
