### PR TITLE
fix: break windows not closing correctly on all platforms

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - snap package not starting on Wayland
+- break windows not closing correctly on all platforms
 
 ## [1.19.0] - 2025-11-13
 ### Added

--- a/app/main.js
+++ b/app/main.js
@@ -77,7 +77,6 @@ let updateChecker
 let currentTrayIconPath = null
 let currentTrayMenuTemplate = null
 let trayUpdateIntervalObj = null
-let skipStrictCloseGuard = false // to allow window closing in strict mode when we want to close it
 
 log.initialize({ preload: true })
 
@@ -444,12 +443,18 @@ function startPowerMonitoring () {
 
 function closeWindows (windowArray) {
   for (const window of windowArray) {
+    if (!window || window.isDestroyed()) {
+      continue
+    }
+
     window.hide()
     if (windowArray[0] === window) {
       ipcMain.removeHandler('send-long-break-data')
       ipcMain.removeHandler('send-mini-break-data')
     }
-    window.close()
+
+    // Use destroy() for immediate, guaranteed cleanup on all platforms
+    window.destroy()
   }
   return null
 }
@@ -781,7 +786,6 @@ function startMicrobreak () {
     microbreakWinLocal.setAlwaysOnTop(!showBreaksAsRegularWindows, 'pop-up-menu')
     if (microbreakWinLocal) {
       microbreakWinLocal.on('close', (e) => {
-        if (skipStrictCloseGuard) return
         if (breakPlanner.scheduler.timeLeft > 0 && settings.get('microbreakStrictMode')) {
           log.info('Stretchly: preventing closing break window as in strict mode')
           e.preventDefault()
@@ -937,7 +941,6 @@ function startBreak () {
     breakWinLocal.setAlwaysOnTop(!showBreaksAsRegularWindows, 'pop-up-menu')
     if (breakWinLocal) {
       breakWinLocal.on('close', (e) => {
-        if (skipStrictCloseGuard) return
         if (breakPlanner.scheduler.timeLeft > 0 && settings.get('breakStrictMode')) {
           log.info('Stretchly: preventing closing break window as in strict mode')
           e.preventDefault()
@@ -975,10 +978,7 @@ function breakComplete (shouldPlaySound, windows, breakType) {
     // get focus on the last app
     Menu.sendActionToFirstResponder('hide:')
   }
-  skipStrictCloseGuard = true
-  const result = closeWindows(windows)
-  skipStrictCloseGuard = false
-  return result
+  return closeWindows(windows)
 }
 
 function enterManualAwaitPhase (type, shouldPlaySound) {


### PR DESCRIPTION
Issue: #1604

### Description of the Change

- Removed 1 global variable, 5 lines from `breakComplete()`, 2 checks from event handlers
- Strict mode still prevents users from closing windows

### Benefits

- More robust: `destroy()` works regardless of platform or window properties
- Clearer intent: Programmatic `destroy()` vs. user-prevented `close()`
- Works everywhere: Consistent behavior across macOS/Linux/Windows

### How It Works Now

#### User tries to close break window
  - `close` event fires → handler checks strict mode → `preventDefault()` blocks it

#### Programmatically closing (finish/postpone/skip)
  - `window.destroy()` called → closed event fires → cleanup happens
  - Bypasses the `close` event entirely (intentional!)

### Verification Process

1. `npm run dist -- --mac --arm64`
2. Install new build in Applications and run for a few hours with regular breaks
3. Check Activity Monitor - confirm no accumulation of renderer processes
4. Check memory usage - should stay < 200 MiB, not grow over time

