### PR TITLE
Fix idle time detection for Wayland

### DIFF
--- a/.github/workflows/arm-build.yml
+++ b/.github/workflows/arm-build.yml
@@ -19,7 +19,7 @@ jobs:
     - uses: actions/setup-node@v3
       with:
         node-version: '22.20.0'
-    - run: sudo apt update && sudo apt-get install --no-install-recommends -y ruby-full libarchive-tools
+    - run: sudo apt update && sudo apt-get install --no-install-recommends -y ruby-full libarchive-tools libinput-dev libudev-dev
     - run: sudo gem install fpm -v 1.15
     - run: npm install npm -g
     - run: npm install

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,9 @@ jobs:
       run: sudo xcode-select -s /Library/Developer/CommandLineTools      
     - name: run on linux
       if: matrix.os == 'ubuntu-latest'
-      run: sudo apt-get install libarchive-tools
+      run: |
+        sudo apt-get update
+        sudo apt-get install -y libarchive-tools libinput-dev libudev-dev pkg-config
     - uses: actions/checkout@v3
     - uses: actions/setup-python@v4
       with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
     - name: run on mac
       if: matrix.os == 'macos-latest'
-      run: sudo xcode-select -s /Library/Developer/CommandLineTools      
+      run: sudo xcode-select -s /Library/Developer/CommandLineTools
     - name: run on linux
       if: matrix.os == 'ubuntu-latest'
       run: |

--- a/.github/workflows/snap-build.yml
+++ b/.github/workflows/snap-build.yml
@@ -18,6 +18,7 @@ jobs:
       with:
         node-version: '22.20.0'
     - run: pip install setuptools
+    - run: sudo apt update && sudo apt-get install --no-install-recommends -y libinput-dev libudev-dev
     - run: npm install -g npm
     - run: npm install
     - run: node_modules/.bin/electron-builder --linux snap --publish=never

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -22,7 +22,7 @@ jobs:
       if: matrix.os == 'ubuntu-latest'
       run: |
         export DISPLAY=:0
-        sudo apt update && sudo apt install dbus-x11
+        sudo apt update && sudo apt install -y dbus-x11 libinput-dev libudev-dev
         machineId=$(cat /var/lib/dbus/machine-id)
         mkdir -p /home/runner/.dbus
         mkdir -p /home/runner/.dbus/session-bus/
@@ -56,6 +56,8 @@ jobs:
     - name: Install missing usocket
       if: matrix.os == 'ubuntu-latest'
       run: npm install usocket
+    - name: Rebuild native modules for Node.js
+      run: npm rebuild node-desktop-idle-v2
     - run: npm run coverage
       env:
         CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased]
 ### Fixed
 - fix focus mode detection on macOS Tahoe
+- fix idle time detection on Wayland
 
 ## [1.20.0] - 2025-12-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -109,6 +109,8 @@ sudo sysctl -w kernel.apparmor_restrict_unprivileged_userns=0
 ```
 Read more [here](https://github.com/electron/electron/issues/17972). Depending on your distro, you probably want to do something similar to this, so the preferences are kept after reboot: Add `kernel.unprivileged_userns_clone=1` and `kernel.apparmor_restrict_unprivileged_userns=0` to `/etc/sysctl.d/00-local-userns.conf` and reboot.
 
+If you're on Wayland and you would like to be able to monitor idle time, you'll need to add your user to `input` group, with `sudo gpasswd --add $USER input` (depending on your distro) and logout/login to take an effect.
+
 ### Running from source
 
 To run *Stretchly* from source you will need [Node.js](https://nodejs.org/), ideally the one specified in `package.json`. Clone the repo, run `npm install` and then simply run `npm start` to start *Stretchly*.
@@ -211,7 +213,7 @@ Here are the preferences editable via the app. If values in the app does not sui
 - `language` - language
 - `useMonochromeTrayIcon` - use monochrome icon
 - `useMonochromeInvertedTrayIcon` - use inverted monochrome icon
-- `trayIconStyle` - icon style for menubar: default, time to break, or progress to break 
+- `trayIconStyle` - icon style for menubar: default, time to break, or progress to break
 - `silentNotifications` - enable sounds
 - `monitorDnd` - monitor DND mode
 - `checkNewVersion` - check for new versions
@@ -451,29 +453,29 @@ Note that this will disable graphical way of opening Stretchly Preferences. To a
 If you want to show tray menu even while in Strict mode, set `showTrayMenuInStrictMode` to `true`.
 
 #### Show custom message in Preferences
-If you want to show custom message in Preferences, set `customPreferencesMessage` to string of your liking. 
+If you want to show custom message in Preferences, set `customPreferencesMessage` to string of your liking.
 
-This might be useful for corporate installations. 
+This might be useful for corporate installations.
 
 #### Disable app update functionality
-If you want to disable functionality around app updates, set `disableAppUpdateFeatures` to `true`. This will make Stretchly not to check for new versions and hide related elements from the app. This value takes preference over `checkNewVersion` and `notifyNewVersion`. 
+If you want to disable functionality around app updates, set `disableAppUpdateFeatures` to `true`. This will make Stretchly not to check for new versions and hide related elements from the app. This value takes preference over `checkNewVersion` and `notifyNewVersion`.
 
-This might be useful for corporate installations. 
+This might be useful for corporate installations.
 
 #### Hide location of preferences file in Debug info
-If you want to hide location of preferences file in Debug info, set `hidePreferencesFileLocation` to `true`. 
+If you want to hide location of preferences file in Debug info, set `hidePreferencesFileLocation` to `true`.
 
 This might be useful for corporate installations.
 
 #### Hide Strict Mode preferences
-If you want to hide Strict Mode preferences section from the Preferences window, set `hideStrictModePreferences` to `true`. 
+If you want to hide Strict Mode preferences section from the Preferences window, set `hideStrictModePreferences` to `true`.
 
-This might be useful for corporate installations. 
+This might be useful for corporate installations.
 
 #### Set automatic start from congfig file
-If you want autostart to work based on the value from config file, set `openAtLogin`. 
+If you want autostart to work based on the value from config file, set `openAtLogin`.
 
-This might be useful for corporate installations. 
+This might be useful for corporate installations.
 
 ## Contributor Preferences
 

--- a/app/utils/naturalBreaksManager.js
+++ b/app/utils/naturalBreaksManager.js
@@ -11,7 +11,6 @@ class NaturalBreaksManager extends EventEmitter {
     this.timer = null
     this.isOnNaturalBreak = false
     this.isSchedulerCleared = false
-    this.isMonitoringStarted = false
     if (this.usingNaturalBreaks) {
       this.start()
     }
@@ -19,10 +18,7 @@ class NaturalBreaksManager extends EventEmitter {
 
   start () {
     this.usingNaturalBreaks = true
-    if (!this.isMonitoringStarted) {
-      desktopIdle.startMonitoring()
-      this.isMonitoringStarted = true
-    }
+    desktopIdle.startMonitoring()
     this._checkIdleTime()
     log.info('Stretchly: starting Idle time monitoring')
   }
@@ -33,21 +29,13 @@ class NaturalBreaksManager extends EventEmitter {
     this.isSchedulerCleared = false
     clearTimeout(this.timer)
     this.timer = null
-    if (this.isMonitoringStarted) {
-      desktopIdle.stopMonitoring()
-      this.isMonitoringStarted = false
-    }
+    desktopIdle.stopMonitoring()
     log.info('Stretchly: stopping Idle time monitoring')
   }
 
   get idleTime () {
     if (this.usingNaturalBreaks) {
-      const idleSeconds = powerMonitor.getSystemIdleTime() || desktopIdle.getIdleTime()
-      if (idleSeconds === -1) {
-        log.warn('Stretchly: Failed to get idle time, monitoring not started')
-        return 0
-      }
-      return idleSeconds * 1000
+      return (powerMonitor.getSystemIdleTime() || desktopIdle.getIdleTime()) * 1000
     } else {
       return 0
     }

--- a/app/utils/naturalBreaksManager.js
+++ b/app/utils/naturalBreaksManager.js
@@ -1,6 +1,7 @@
 import EventEmitter from 'events'
 import log from 'electron-log/main.js'
 import { desktopIdle } from 'node-desktop-idle-v2'
+import { powerMonitor } from 'electron'
 
 class NaturalBreaksManager extends EventEmitter {
   constructor (settings) {
@@ -41,7 +42,7 @@ class NaturalBreaksManager extends EventEmitter {
 
   get idleTime () {
     if (this.usingNaturalBreaks) {
-      const idleSeconds = desktopIdle.getIdleTime()
+      const idleSeconds = powerMonitor.getSystemIdleTime() || desktopIdle.getIdleTime()
       if (idleSeconds === -1) {
         log.warn('Stretchly: Failed to get idle time, monitoring not started')
         return 0

--- a/app/utils/naturalBreaksManager.js
+++ b/app/utils/naturalBreaksManager.js
@@ -1,6 +1,6 @@
 import EventEmitter from 'events'
 import log from 'electron-log/main.js'
-import { powerMonitor } from 'electron'
+import { desktopIdle } from 'node-desktop-idle-v2'
 
 class NaturalBreaksManager extends EventEmitter {
   constructor (settings) {
@@ -10,6 +10,7 @@ class NaturalBreaksManager extends EventEmitter {
     this.timer = null
     this.isOnNaturalBreak = false
     this.isSchedulerCleared = false
+    this.isMonitoringStarted = false
     if (this.usingNaturalBreaks) {
       this.start()
     }
@@ -17,6 +18,10 @@ class NaturalBreaksManager extends EventEmitter {
 
   start () {
     this.usingNaturalBreaks = true
+    if (!this.isMonitoringStarted) {
+      desktopIdle.startMonitoring()
+      this.isMonitoringStarted = true
+    }
     this._checkIdleTime()
     log.info('Stretchly: starting Idle time monitoring')
   }
@@ -27,12 +32,21 @@ class NaturalBreaksManager extends EventEmitter {
     this.isSchedulerCleared = false
     clearTimeout(this.timer)
     this.timer = null
+    if (this.isMonitoringStarted) {
+      desktopIdle.stopMonitoring()
+      this.isMonitoringStarted = false
+    }
     log.info('Stretchly: stopping Idle time monitoring')
   }
 
   get idleTime () {
     if (this.usingNaturalBreaks) {
-      return powerMonitor.getSystemIdleTime() * 1000
+      const idleSeconds = desktopIdle.getIdleTime()
+      if (idleSeconds === -1) {
+        log.warn('Stretchly: Failed to get idle time, monitoring not started')
+        return 0
+      }
+      return idleSeconds * 1000
     } else {
       return 0
     }

--- a/package.json
+++ b/package.json
@@ -161,6 +161,7 @@
     "i18next-fs-backend": "^2.6.1",
     "luxon": "^3.7.2",
     "meeussunmoon": "^3.1.0",
+    "node-desktop-idle-v2": "^1.1.18",
     "ps-list": "^9.0.0",
     "semver": "^7.7.3",
     "windows-focus-assist": "^1.4.0"

--- a/test/naturalBreaksManager.js
+++ b/test/naturalBreaksManager.js
@@ -6,9 +6,11 @@ import defaultSettings from '../app/utils/defaultSettings'
 import { unlink } from 'node:fs'
 import { vi } from 'vitest'
 
-vi.mock('electron', () => ({
-  powerMonitor: {
-    getSystemIdleTime: () => 0
+vi.mock('node-desktop-idle-v2', () => ({
+  desktopIdle: {
+    getIdleTime: () => 0,
+    startMonitoring: () => {},
+    stopMonitoring: () => {}
   }
 }))
 

--- a/test/naturalBreaksManager.js
+++ b/test/naturalBreaksManager.js
@@ -4,15 +4,6 @@ import NaturalBreaksManager from '../app/utils/naturalBreaksManager'
 import Store from 'electron-store'
 import defaultSettings from '../app/utils/defaultSettings'
 import { unlink } from 'node:fs'
-import { vi } from 'vitest'
-
-vi.mock('node-desktop-idle-v2', () => ({
-  desktopIdle: {
-    getIdleTime: () => 0,
-    startMonitoring: () => {},
-    stopMonitoring: () => {}
-  }
-}))
 
 describe('naturalBreaksManager', function () {
   let settings = null


### PR DESCRIPTION
Hi,
Issue: closes #1622 

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [ ]  package versions and package-lock.json were not changed (`npm install --no-save`). --> Had to be because we're adding a new package (`npm install node-desktop-idle-v2`)
- [x]  app version number was not changed.
- [x]  all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [ ]  README and CHANGELOG were updated accordingly.
- [x]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change
As discussed in the issue, electron's `getSystemIdleTime` just doesn't work on Wayland, so it had to be replaced with https://github.com/MomoRazor/node-desktop-idle-v2. See https://github.com/MomoRazor/node-desktop-idle-v2/issues/1.

### Verification Process
Tested on:
- Arch, Wayland 1.24.0-1
- MacOS Tahoe 26.1

Idle is detected as expected, and the natural pause is stopped as soon as I move my mouse.

Thanks !
