### PR TITLE
Fix focus mode detection on macOS Tahoe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/)
 and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
+### Fixed
+- fix focus mode detection on macOS Tahoe
 
 ## [1.20.0] - 2025-12-24
 ### Added

--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ You can help to translate Stretchly on [Weblate](https://hosted.weblate.org/enga
 - Aleh, [@alehpa](https://github.com/alehpa)
 - Philip Wintersteiner, [@Wikiwix](https://github.com/wikiwix)
 - Steven Cai, [@stevencaiOR](https://github.com/stevencaiOR)
+- Zhekai Jiang, [@zhekai-jiang](https://github.com/zhekai-jiang)
 
 Also see Github's list of [contributors](https://github.com/hovancik/stretchly/graphs/contributors).
 

--- a/app/utils/dndManager.js
+++ b/app/utils/dndManager.js
@@ -141,14 +141,24 @@ class DndManager extends EventEmitter {
         } catch (e) { wfa = -1 } // getFocusAssist() throw an error if OS isn't windows
         return wfa !== -1 && wfa !== 0
       } else if (process.platform === 'darwin') {
+        const macOSMajorVersion = parseInt(process.getSystemVersion().split('.')[0])
+        let cmd = ''
+        if (macOSMajorVersion >= 26) {
+          cmd = 'defaults read com.apple.controlcenter "NSStatusItem VisibleCC FocusModes"'
+        } else {
+          cmd = 'defaults read com.apple.controlcenter "NSStatusItem Visible FocusModes"'
+        }
         try {
           const asyncExec = this._getOrCreateAsyncExec()
-          const { stdout } = await asyncExec('defaults read com.apple.controlcenter "NSStatusItem Visible FocusModes"')
+          const { stdout } = await asyncExec(cmd)
           if (stdout.replace(/[^0-9a-zA-Z]/g, '') === '1') {
             return true
           }
         } catch (e) {
-          this._logErrorOnce('macos', e)
+          if (!e.message.includes('The domain/default pair of (com.apple.controlcenter, NSStatusItem VisibleCC FocusModes) does not exist')) {
+            // On macOS Tahoe 26.0, this entry would not exist if no focus mode is enabled
+            this._logErrorOnce('macos', e)
+          }
         }
       } else if (process.platform === 'linux') {
         return await this._isDndEnabledLinux()


### PR DESCRIPTION
<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: #1728 
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [x]  issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [x]  during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions. – I suppose it's tricky to write a unit test for this feature as it is OS-specific. I see no unit test that actually checks this functionality in [test/dndManager.js](https://github.com/hovancik/stretchly/blob/trunk/test/dndManager.js) yet.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

### Description of the Change

<!--

We must be able to understand the design of your change from this description. If we can't get a good idea of what the code will be doing from the description here, the pull request may be closed at the maintainers' discretion. Keep in mind that the maintainer reviewing this PR may not be familiar with or have worked with the code here recently, so please walk us through the concepts.

-->

On macOS, we now check the version of the system and apply different commands to check for focus modes.


### Verification Process

<!--

What process did you follow to verify that your change has the desired effects?

- How did you verify that all new functionality works as expected?
- How did you verify that all changed functionality works as expected?
- How did you verify that the change has not introduced any regressions?

Describe the actions you performed (e.g., buttons you clicked, text you typed, commands you ran, etc.), and describe the results you observed.

-->

Actions:
1. Uncheck "Show breaks even in Do Not Disturb mode" in preferences
2. Activate a focus mode
3. Deactivate focus mode

Results:
Breaks are paused immediately as focus mode is activated. When it is then deactivated, break resumes after a few seconds (There seems to be this delay for the system to update the flag that is being checked).


### Other information
