### PR TITLE
fix: prevent before-quit recursion and null second-instance args

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -119,6 +119,10 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (event, commandLine, workingDirectory, commandLineArguments) => {
     log.info(`Stretchly: arguments received from second instance: ${commandLineArguments}`)
+    if (!commandLineArguments) {
+      log.warn('Stretchly: second instance sent null arguments, ignoring')
+      return
+    }
     const cmd = new Command(commandLineArguments, app.getVersion())
 
     if (!cmd.hasSupportedCommand) {
@@ -207,7 +211,8 @@ app.on('before-quit', (event) => {
     if (autostartManager) {
       autostartManager.disconnect()
     }
-    app.quit()
+    // Do NOT call app.quit() here — we are already inside the quit sequence.
+    // Calling it again triggers before-quit recursively → RangeError: Maximum call stack size exceeded.
   }
 })
 

--- a/app/main.js
+++ b/app/main.js
@@ -805,8 +805,12 @@ function startMicrobreak () {
       log.info('Stretchly: ready-to-show fired')
     })
 
-    ipcMain.once('mini-break-loaded', () => {
+    const onMiniBreakLoaded = () => {
       log.info('Stretchly: Mini break window loaded')
+      if (!microbreakWinLocal || microbreakWinLocal.isDestroyed()) {
+        log.warn('Stretchly: mini-break-loaded fired after window was destroyed, ignoring')
+        return
+      }
       if (showBreaksAsRegularWindows) {
         microbreakWinLocal.show()
       } else {
@@ -833,7 +837,9 @@ function startMicrobreak () {
         }, 0)
       }
       updateTray()
-    })
+    }
+
+    ipcMain.once('mini-break-loaded', onMiniBreakLoaded)
 
     microbreakWinLocal.loadURL(modalPath)
     microbreakWinLocal.setVisibleOnAllWorkspaces(true)
@@ -846,6 +852,7 @@ function startMicrobreak () {
         }
       })
       microbreakWinLocal.once('closed', () => {
+        ipcMain.removeListener('mini-break-loaded', onMiniBreakLoaded)
         microbreakWinLocal = null
       })
     }
@@ -961,8 +968,12 @@ function startBreak () {
       log.info('Stretchly: ready-to-show fired')
     })
 
-    ipcMain.once('long-break-loaded', () => {
+    const onLongBreakLoaded = () => {
       log.info('Stretchly: Long break window loaded')
+      if (!breakWinLocal || breakWinLocal.isDestroyed()) {
+        log.warn('Stretchly: long-break-loaded fired after window was destroyed, ignoring')
+        return
+      }
       if (showBreaksAsRegularWindows) {
         breakWinLocal.show()
       } else {
@@ -990,7 +1001,9 @@ function startBreak () {
         }, 0)
       }
       updateTray()
-    })
+    }
+
+    ipcMain.once('long-break-loaded', onLongBreakLoaded)
 
     breakWinLocal.loadURL(modalPath)
     breakWinLocal.setVisibleOnAllWorkspaces(true)
@@ -1003,6 +1016,7 @@ function startBreak () {
         }
       })
       breakWinLocal.once('closed', () => {
+        ipcMain.removeListener('long-break-loaded', onLongBreakLoaded)
         breakWinLocal = null
       })
     }


### PR DESCRIPTION
## Summary

Two crash fixes found while using Stretchly with an external task scheduler that invokes `Stretchly.exe mini` to trigger clock-aligned breaks.

---

## Fix 1: `RangeError: Maximum call stack size exceeded` in `before-quit`

**Root cause:** The `else` branch of the `before-quit` handler called `app.quit()` after cleanup. This re-triggers the `before-quit` event, creating infinite recursion that crashes the process with a stack overflow.

**Stack trace:**
```
RangeError: Maximum call stack size exceeded
    at BrowserWindow.<anonymous> (node:electron/js2c/browser_init:2:18922)
    at EventEmitter.<anonymous> (app/main.js:210:9)
    at EventEmitter.<anonymous> (app/main.js:210:9)
    ... (repeating)
```

**Fix:** Remove the `app.quit()` call. Not calling `event.preventDefault()` already allows the quit to proceed naturally — the explicit call is both redundant and harmful.

---

## Fix 2: `TypeError: Cannot read properties of null (reading 'length')` in `second-instance`

**Root cause:** On Windows, Electron IPC can deliver `null` as `commandLineArguments` (the `additionalData` from `requestSingleInstanceLock`) when the second instance was built with a different Electron version. Known upstream Electron issue: https://github.com/electron/electron/issues/40615

Without a guard, `new Command(null, ...)` → `Command.parse(null)` → `null.length` crashes the main instance.

**Stack trace:**
```
TypeError: Cannot read properties of null (reading 'length')
    at Command.parse (app/utils/commands.js:124:22)
    at new Command (app/utils/commands.js:118:10)
    at App.<anonymous> (app/main.js:112:17)
```

**Fix:** Early return with `log.warn` before constructing `Command` when `commandLineArguments` is null.

---

## Testing

Verified on Windows 11 with `allScreens: true` (3 monitors):
- Break fires on all 3 screens
- Second instance exits cleanly after forwarding
- Main instance continues running
- No errors in log