### PR TITLE
fix: remove stale ipcMain listeners when break windows are destroyed (#1572)

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -800,8 +800,12 @@ function startMicrobreak () {
       log.info('Stretchly: ready-to-show fired')
     })
 
-    ipcMain.once('mini-break-loaded', () => {
+    const onMiniBreakLoaded = () => {
       log.info('Stretchly: Mini break window loaded')
+      if (!microbreakWinLocal || microbreakWinLocal.isDestroyed()) {
+        log.warn('Stretchly: mini-break-loaded fired after window was destroyed, ignoring')
+        return
+      }
       if (showBreaksAsRegularWindows) {
         microbreakWinLocal.show()
       } else {
@@ -828,7 +832,9 @@ function startMicrobreak () {
         }, 0)
       }
       updateTray()
-    })
+    }
+
+    ipcMain.once('mini-break-loaded', onMiniBreakLoaded)
 
     microbreakWinLocal.loadURL(modalPath)
     microbreakWinLocal.setVisibleOnAllWorkspaces(true)
@@ -841,6 +847,7 @@ function startMicrobreak () {
         }
       })
       microbreakWinLocal.once('closed', () => {
+        ipcMain.removeListener('mini-break-loaded', onMiniBreakLoaded)
         microbreakWinLocal = null
       })
     }
@@ -956,8 +963,12 @@ function startBreak () {
       log.info('Stretchly: ready-to-show fired')
     })
 
-    ipcMain.once('long-break-loaded', () => {
+    const onLongBreakLoaded = () => {
       log.info('Stretchly: Long break window loaded')
+      if (!breakWinLocal || breakWinLocal.isDestroyed()) {
+        log.warn('Stretchly: long-break-loaded fired after window was destroyed, ignoring')
+        return
+      }
       if (showBreaksAsRegularWindows) {
         breakWinLocal.show()
       } else {
@@ -985,7 +996,9 @@ function startBreak () {
         }, 0)
       }
       updateTray()
-    })
+    }
+
+    ipcMain.once('long-break-loaded', onLongBreakLoaded)
 
     breakWinLocal.loadURL(modalPath)
     breakWinLocal.setVisibleOnAllWorkspaces(true)
@@ -998,6 +1011,7 @@ function startBreak () {
         }
       })
       breakWinLocal.once('closed', () => {
+        ipcMain.removeListener('long-break-loaded', onLongBreakLoaded)
         breakWinLocal = null
       })
     }


### PR DESCRIPTION
## Problem

Pressing the skip-to-break shortcut twice quickly (> 100 ms apart) crashes the app 100% of the time:

```
TypeError: Cannot read properties of null (reading 'showInactive')
    at IpcMainImpl.<anonymous> (app/main.js:781:28)
```

## Root cause

`startMicrobreak()` loops over displays and registers `ipcMain.once('mini-break-loaded', handler)` for each one. Each handler closes over the local `microbreakWinLocal` variable for that display.

When the shortcut fires a second time, `skipToMicrobreak()` calls `breakComplete()` which destroys the in-flight windows. The `'closed'` event fires and sets `microbreakWinLocal = null`. **The `ipcMain.once` handlers, however, are still registered on the global `ipcMain`.**

A second `startMicrobreak()` then creates new windows. Those new windows fire `'mini-break-loaded'`, which drains the stale handlers first (FIFO). Each stale handler calls `microbreakWinLocal.showInactive()` on a null reference → crash. The real handlers for the new windows never get a chance to run, so the new windows also stay invisible.

Sequence from the reporter's log (2 displays, presses 174 ms apart):



The same pattern exists in `startBreak()` / `'long-break-loaded'`.

## Fix

Name each `ipcMain.once` handler so it can be referenced, then call `ipcMain.removeListener()` from the window's `'closed'` callback. When a window is destroyed, its handler is immediately deregistered before any new windows fire the same event.

A `null`/`isDestroyed()` guard is added inside each handler as a belt-and-suspenders fallback.

```js
// before
ipcMain.once('mini-break-loaded', () => {
  microbreakWinLocal.showInactive()  // crashes if window was destroyed first
})
microbreakWinLocal.once('closed', () => {
  microbreakWinLocal = null           // handler still registered on ipcMain!
})

// after
const onMiniBreakLoaded = () => {
  if (!microbreakWinLocal || microbreakWinLocal.isDestroyed()) return
  microbreakWinLocal.showInactive()
}
ipcMain.once('mini-break-loaded', onMiniBreakLoaded)
microbreakWinLocal.once('closed', () => {
  ipcMain.removeListener('mini-break-loaded', onMiniBreakLoaded)  // ← the fix
  microbreakWinLocal = null
})
```

## Testing

Existing test suite passes (45 tests). The two pre-existing failures in `naturalBreaksManager` and `dndManager` are unrelated — they poll OS-level idle/DND APIs unavailable in the test environment and fail before this change too.

Closes #1572