### PR TITLE
fix: prevent before-quit recursion and crash on null second-instance args

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -119,6 +119,10 @@ if (!gotTheLock) {
 } else {
   app.on('second-instance', (event, commandLine, workingDirectory, commandLineArguments) => {
     log.info(`Stretchly: arguments received from second instance: ${commandLineArguments}`)
+    if (!commandLineArguments) {
+      log.warn('Stretchly: second instance sent null arguments, ignoring')
+      return
+    }
     const cmd = new Command(commandLineArguments, app.getVersion())
 
     if (!cmd.hasSupportedCommand) {
@@ -207,7 +211,8 @@ app.on('before-quit', (event) => {
     if (autostartManager) {
       autostartManager.disconnect()
     }
-    app.quit()
+    // Do NOT call app.quit() here — we are already inside the quit sequence.
+    // Calling it again triggers before-quit recursively → RangeError: Maximum call stack size exceeded.
   }
 })
 


### PR DESCRIPTION
## Two crashes fixed

### 1. `RangeError: Maximum call stack size exceeded` on quit

`app.quit()` was called inside the `before-quit` handler's else branch:

```js
app.on('before-quit', (event) => {
  if (strictModeActive) {
    event.preventDefault()
  } else {
    autostartManager.disconnect()
    app.quit()  // ← triggers before-quit again → infinite recursion
  }
})
```

`app.quit()` re-emits `before-quit`, which calls `app.quit()` again, and so on until the stack overflows. Not calling `event.preventDefault()` already allows the quit to proceed — the explicit `app.quit()` is both redundant and harmful.

**Fix**: remove `app.quit()`. Added a comment explaining why it must not be here.

---

### 2. `TypeError: Cannot read properties of null (reading 'length')` on second instance

On Windows, Electron can deliver `null` as `additionalData` in the `second-instance` event when the second instance was built with a different Electron version (known upstream issue: [electron/electron#40615](https://github.com/electron/electron/issues/40615)). Without a guard, `Command.parse(null)` throws immediately, then the uncaught exception hits the broken `before-quit` handler above, producing the recursive crash on top.

```
Stretchly: arguments received from second instance: null
TypeError: Cannot read properties of null (reading 'length')
  at Command.parse (commands.js:124:22)
...
RangeError: Maximum call stack size exceeded
```

**Fix**: early return with a warning log when `commandLineArguments` is null.

---

## Testing

Existing test suite passes (140 tests across 9 files). Verified locally on Windows 11 — the installed release version and a locally built version can coexist without crashing either instance.