### PR TITLE
docs: update Homebrew installation instructions for Stretchly

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,8 +31,10 @@ Requires macOS Monterey (12) or later.
 It is recommended to install *Stretchly* with [Homebrew tap](https://github.com/hovancik/homebrew-stretchly) by running the following command.
 See [Application Signing](#application-signing) for details.
 ```zsh
-brew install --cask --no-quarantine hovancik/stretchly/stretchly
+brew install --cask hovancik/stretchly/stretchly
 ```
+
+> Note for macOS users: Homebrew recently disabled the `--no-quarantine` flag. As a result, macOS Gatekeeper may block the app on its first launch, showing an "unidentified developer" warning. To bypass this, go to `System Settings > Privacy & Security`, scroll down, and click Open Anyway next to the Stretchly alert. Alternatively, locate the app in Finder, Control-click (or Right-click) its icon, and select Open.
 
 When upgrading, run the following command.
 Don't forget to Quit Stretchly, first.


### PR DESCRIPTION
Removed the --no-quarantine flag from the Homebrew installation command and added a note for macOS users regarding Gatekeeper.

<!--

Have you read Code of Conduct? By filing an Pull Request, you are expected to comply with it, including treating everyone with respect: https://github.com/hovancik/stretchly/blob/master/CODE_OF_CONDUCT.md

-->

Issue: N/A (Minor documentation update)
<!-- Link to relevant issue. All PRs should be associated with an issue -->

### Requirements

* Filling out the template is required. Any pull request that does not include enough information to be reviewed in a timely manner may be closed at the maintainers' discretion.

<!-- If there’s a checkbox you can’t complete for any reason, that's okay, just explain in detail why you weren’t able to do so. -->

- [ ] issue was opened to discuss proposed changes before starting implementation. It is important do discuss changes before implementing them (Why should we add it? How should it work? How should it look? Where will it be? ...).
- [ ] during development, `node` version specified in `package.json` was used (ie using [nvm](https://github.com/creationix/nvm)).
- [x] package versions and package-lock.json were not changed (`npm install --no-save`).
- [x] app version number was not changed.
- [ ] all new code has tests to ensure against regressions.
- [x] `npm run lint` reports no offenses.
- [x] `npm run test` is error-free.
- [x] README and CHANGELOG were updated accordingly.
- [ ] after PR is approved, all commits in it are [squashed](https://gitbetter.substack.com/p/how-to-squash-git-commits)

**Note on unchecked boxes:** I left some boxes unchecked because this is strictly a documentation update to the `README.md` file. No application code, dependencies, or test suites were modified, and an issue was not opened prior since this is a quick fix for a broken installation command.

### Description of the Change

Homebrew recently disabled the `--[no-]quarantine` switch. As a result, users attempting to install Stretchly using the command currently provided in the README encounter the following error:
`Error: Calling the --[no-]quarantine switch is disabled! There is no replacement.`

This PR fixes the documentation by:
1. Removing the deprecated `--no-quarantine` flag from the Homebrew installation command.
2. Adding a note specifically for macOS users explaining that Gatekeeper may block the app on its first launch (due to the missing flag) and providing the standard instructions to bypass it via `System Settings > Privacy & Security`.

### Verification Process

- Ran the updated `brew install --cask hovancik/stretchly/stretchly` command locally on macOS to verify it successfully downloads and installs the app without throwing the Homebrew switch error.
- Verified that launching the newly installed app triggers the expected macOS Gatekeeper "unidentified developer" prompt.
- Followed the documented steps (System Settings > Privacy & Security > Open Anyway) to ensure the bypass instructions are accurate and work correctly on recent macOS versions.
- Previewed the `README.md` markdown changes to ensure correct formatting and readability.

### Other information

This is a documentation-only pull request aimed at improving the onboarding experience for new macOS users.