### PR TITLE
Fix fullscreen breaks dropping out of their Space on macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - fix custom title for Mini break from command line
 - fix repeated crash windows after an error
 - improve double-click error prevention in breaks
+- fix fullscreen breaks dropping out of their Space after a few seconds on macOS
 
 ## [1.21.0] - 2026-04-25
 ### Added

--- a/README.md
+++ b/README.md
@@ -679,6 +679,7 @@ You can help to translate Stretchly on [Weblate](https://hosted.weblate.org/enga
 - Philip Wintersteiner, [@Wikiwix](https://github.com/wikiwix)
 - Steven Cai, [@stevencaiOR](https://github.com/stevencaiOR)
 - Zhekai Jiang, [@zhekai-jiang](https://github.com/zhekai-jiang)
+- Bence Kovács, [@githappens](https://github.com/githappens)
 
 Also see Github's list of [contributors](https://github.com/hovancik/stretchly/graphs/contributors).
 

--- a/app/main.js
+++ b/app/main.js
@@ -870,7 +870,10 @@ function startMicrobreak () {
     ipcMain.on('mini-break-loaded', onMiniBreakLoaded)
 
     microbreakWinLocal.loadURL(isBlank ? modalPath + '?blank=1' : modalPath)
-    microbreakWinLocal.setVisibleOnAllWorkspaces(true)
+    // kiosk fullscreen owns its own Space; CanJoinAllSpaces would eject it (menu bar returns)
+    if (!(process.platform === 'darwin' && !showBreaksAsRegularWindows && settings.get('fullscreen'))) {
+      microbreakWinLocal.setVisibleOnAllWorkspaces(true)
+    }
     microbreakWinLocal.setAlwaysOnTop(!showBreaksAsRegularWindows, 'pop-up-menu')
     if (microbreakWinLocal) {
       microbreakWinLocal.on('close', (e) => {
@@ -1037,7 +1040,10 @@ function startBreak () {
     ipcMain.on('long-break-loaded', onLongBreakLoaded)
 
     breakWinLocal.loadURL(isBlank ? modalPath + '?blank=1' : modalPath)
-    breakWinLocal.setVisibleOnAllWorkspaces(true)
+    // kiosk fullscreen owns its own Space; CanJoinAllSpaces would eject it (menu bar returns)
+    if (!(process.platform === 'darwin' && !showBreaksAsRegularWindows && settings.get('fullscreen'))) {
+      breakWinLocal.setVisibleOnAllWorkspaces(true)
+    }
     breakWinLocal.setAlwaysOnTop(!showBreaksAsRegularWindows, 'pop-up-menu')
     if (breakWinLocal) {
       breakWinLocal.on('close', (e) => {


### PR DESCRIPTION
Closes #1806

### Requirements

- [ ]  issue was opened to discuss proposed changes before starting implementation. _Issue #1806 was opened alongside this PR rather than strictly before implementation — happy to discuss before it is merged._
- [ ]  during development, `node` version specified in `package.json` was used. _No build step is involved; the change is a runtime guard in `app/main.js`._
- [x]  package versions and package-lock.json were not changed (`npm install --no-save`).
- [x]  app version number was not changed.
- [ ]  all new code has tests to ensure against regressions. _The fix concerns macOS `NSWindow` collection-behavior reconciliation, which is not reproducible in the (non-macOS, no-window) unit-test environment._
- [x] `npm run lint` reports no offenses. _Full StandardJS run is clean on this branch._
- [ ] `npm run test` is error-free. _All 250 tests pass; a few test files fail to collect locally due to missing optional packages in my environment, unrelated to this change._
- [x]  README and CHANGELOG were updated accordingly.
- [ ]  after PR is approved, all commits in it are squashed. _Will squash on approval._

### Description of the Change

On macOS with **Fullscreen** breaks enabled, a break window correctly enters fullscreen on its own Space, but a few seconds later — with no user interaction — it silently drops out: the menu bar reappears and the window is no longer on its dedicated Space. This also weakens strict-mode breaks, since the menu bar and other Spaces become reachable again.

Cause: each break window is given two contradictory macOS window collection behaviors:

- `setKiosk(true)` (when Fullscreen is enabled) → `NSWindowCollectionBehaviorFullScreenPrimary`, the window owns a dedicated fullscreen Space.
- `setVisibleOnAllWorkspaces(true)` → `NSWindowCollectionBehaviorCanJoinAllSpaces`.

`CanJoinAllSpaces` and `FullScreenPrimary` are mutually exclusive — a window that joins all Spaces cannot also own a dedicated fullscreen Space. macOS honors kiosk briefly, then reconciles the conflict by ejecting the window from its Space, which is the "drops out after a few seconds" symptom.

Fix: skip `setVisibleOnAllWorkspaces(true)` for kiosk-fullscreen break windows (macOS, overlay breaks, Fullscreen enabled) — they already own their Space, so the flag is both redundant and the source of the conflict. Applied to both Mini (`startMicrobreak`) and Long (`startBreak`) breaks. Non-fullscreen breaks, regular-window breaks, and other platforms are unchanged.

### Verification Process

- macOS, Fullscreen enabled: triggered Mini and Long breaks and left them untouched — they now stay fullscreen on their own Space instead of dropping out after ~10s.
- Confirmed non-fullscreen breaks and the regular-window break mode are unchanged.
- Behavior on Windows/Linux is unaffected (guard is `process.platform === 'darwin'` only).
- `npm run lint` clean.

### Other information

The guard condition mirrors the existing kiosk/fullscreen logic so non-macOS and non-fullscreen paths keep calling `setVisibleOnAllWorkspaces(true)` exactly as before.
