### PR TITLE
fix: cancel orphaned finish scheduler when a second break starts

### DIFF
--- a/app/breaksPlanner.js
+++ b/app/breaksPlanner.js
@@ -19,12 +19,14 @@ class BreaksPlanner extends EventEmitter {
 
     this.on('microbreakStarted', (shouldPlaySound) => {
       const interval = this.settings.get('microbreakDuration')
+      if (this.scheduler) this.scheduler.cancel()
       this.scheduler = new Scheduler(() => this.emit('finishMicrobreak', shouldPlaySound, true), interval, 'finishMicrobreak')
       this.scheduler.plan()
     })
 
     this.on('breakStarted', (shouldPlaySound) => {
       const interval = this.settings.get('breakDuration')
+      if (this.scheduler) this.scheduler.cancel()
       this.scheduler = new Scheduler(() => this.emit('finishBreak', shouldPlaySound, true), interval, 'finishBreak')
       this.scheduler.plan()
     })

--- a/app/main.js
+++ b/app/main.js
@@ -517,6 +517,7 @@ function startPowerMonitoring () {
 }
 
 function closeWindows (windowArray) {
+  if (!windowArray || !Array.isArray(windowArray)) return null
   for (const window of windowArray) {
     if (!window || window.isDestroyed()) {
       continue

--- a/test/breaksPlanner.js
+++ b/test/breaksPlanner.js
@@ -1,0 +1,79 @@
+import 'chai/register-should'
+import { join } from 'path'
+import BreaksPlanner from '../app/breaksPlanner'
+import Store from 'electron-store'
+import defaultSettings from '../app/utils/defaultSettings'
+import { unlink } from 'node:fs'
+import { vi } from 'vitest'
+
+const timeout = process.env.CI ? 30000 : 10000
+
+describe('breaksPlanner', function () {
+  vi.setConfig({ testTimeout: timeout })
+  let settings = null
+  let breaksPlanner = null
+
+  beforeEach(() => {
+    settings = new Store({
+      cwd: join(__dirname),
+      name: 'test-settings-breaksPlanner',
+      defaults: defaultSettings
+    })
+    settings.set('microbreakDuration', 200)
+    settings.set('breakDuration', 500)
+    settings.set('microbreak', true)
+    settings.set('break', true)
+    breaksPlanner = new BreaksPlanner(settings)
+  })
+
+  afterEach(() => {
+    if (breaksPlanner.scheduler) breaksPlanner.scheduler.cancel()
+    unlink(join(__dirname, 'test-settings-breaksPlanner.json'), () => {})
+  })
+
+  it('cancels the previous finish scheduler when a second break starts', () =>
+    new Promise((resolve) => {
+      let finishBreakFired = false
+
+      breaksPlanner.on('finishBreak', () => {
+        finishBreakFired = true
+      })
+
+      // Start a long break — creates a finishBreak scheduler (500ms)
+      breaksPlanner.emit('breakStarted', false)
+
+      // Start a mini break 50ms later — should cancel the finishBreak scheduler
+      setTimeout(() => {
+        breaksPlanner.emit('microbreakStarted', false)
+      }, 50)
+
+      // After 600ms the original finishBreak timer would have fired if not cancelled
+      setTimeout(() => {
+        finishBreakFired.should.equal(false)
+        resolve()
+      }, 600)
+    }))
+
+  it('cancels the previous finish scheduler when a long break follows a mini break', () =>
+    new Promise((resolve) => {
+      let finishMicrobreakFired = false
+
+      breaksPlanner.on('finishMicrobreak', () => {
+        finishMicrobreakFired = true
+      })
+
+      // Start a mini break — creates a finishMicrobreak scheduler (200ms)
+      breaksPlanner.emit('microbreakStarted', false)
+
+      // Start a long break 50ms later — should cancel the finishMicrobreak scheduler
+      setTimeout(() => {
+        breaksPlanner.emit('breakStarted', false)
+      }, 50)
+
+      // After 300ms the original finishMicrobreak timer would have fired if not cancelled
+      setTimeout(() => {
+        finishMicrobreakFired.should.equal(false)
+        resolve()
+      }, 300)
+    }))
+})


### PR DESCRIPTION
When two breaks start in quick succession via concurrent CLI calls, the `breakStarted` handler assigns a new `Scheduler` to `this.scheduler` without cancelling the existing `finishMicrobreak` timer. That timer keeps running independently. If the screen locks before it fires, both breaks are force-closed and `microbreakWins` is set to `null`. When the orphaned timer fires shortly after, it calls `finishMicrobreak` against `null` and throws.

The fix cancels the previous scheduler in both `microbreakStarted` and `breakStarted` before creating the new one. A null guard in `closeWindows` is included as a defensive fallback.

Tests in `test/breaksPlanner.js` verify that emitting `breakStarted` while a `finishMicrobreak` timer is running cancels the orphaned timer, and vice versa.

To reproduce: run `stretchly long` and `stretchly mini` within a second of each other, then lock the screen while both overlays are active and keep it locked for at least the Mini break duration. Fixes #1802.