### PR TITLE
feat: lock break exits for the opening part of a break

### DIFF
--- a/app/break-renderer.js
+++ b/app/break-renderer.js
@@ -56,6 +56,7 @@ window.onload = async (event) => {
   const progressTime = document.querySelector('#progress-time')
   const postponeElement = document.querySelector('#postpone')
   const closeElement = document.querySelector('#close')
+  const lockHintElement = document.querySelector('#lock-hint')
   const manualFinishElement = document.querySelector('#finish')
   document.body.classList.add(mainColor.substring(1))
   document.body.style.backgroundColor = backgroundColor
@@ -96,6 +97,15 @@ window.onload = async (event) => {
           closeElement.classList.remove('hidden')
         } else {
           closeElement.classList.add('hidden')
+        }
+        if (lockedPercent > 0 && passedPercent < lockedPercent) {
+          lockHintElement.classList.remove('hidden')
+          if (secondChanged) {
+            lockHintElement.innerHTML = await window.utils.formatSkippableIn(
+              duration * lockedPercent / 100 - passed, locale)
+          }
+        } else {
+          lockHintElement.classList.add('hidden')
         }
         progress.value = (100 - passedPercent) * progress.max / 100
         if (secondChanged) {

--- a/app/break-renderer.js
+++ b/app/break-renderer.js
@@ -5,7 +5,8 @@ import './platform.js'
 
 window.onload = async (event) => {
   const [idea, started, duration, strictMode, postpone,
-    postponePercent, backgroundColor, danger, breakHealthMode] = await window.breaks.sendBreakData()
+    postponePercent, backgroundColor, danger, breakHealthMode,
+    lockedPercent] = await window.breaks.sendBreakData()
 
   document.ondragover = event =>
     event.preventDefault()
@@ -86,12 +87,12 @@ window.onload = async (event) => {
     if (!manualAwaiting) {
       if (passed < duration) {
         const passedPercent = passed / duration * 100
-        if (window.utils.canPostpone(postpone, passedPercent, postponePercent)) {
+        if (window.utils.canPostpone(postpone, passedPercent, postponePercent, lockedPercent)) {
           postponeElement.classList.remove('hidden')
         } else {
           postponeElement.classList.add('hidden')
         }
-        if (window.utils.canSkip(strictMode, postpone, passedPercent, postponePercent)) {
+        if (window.utils.canSkip(strictMode, postpone, passedPercent, postponePercent, lockedPercent)) {
           closeElement.classList.remove('hidden')
         } else {
           closeElement.classList.add('hidden')

--- a/app/break.html
+++ b/app/break.html
@@ -19,6 +19,7 @@
         <span id='progress-time' aria-hidden="true"></span>
       </div>
       <div>
+        <span id="lock-hint" class="hidden" aria-live="polite"></span>
         <a id="postpone" class="tooltip top hidden">
           <span data-i18next="break.postpone"></span>
           <img src="images/breaks/break-postpone.svg" />

--- a/app/contributor-preferences.html
+++ b/app/contributor-preferences.html
@@ -120,6 +120,34 @@
         <output data-unit="percent"></output>
       </div>
       <div>
+        <label data-i18next="contributorPreferences.lockedFor" data-same-width-label for="miniBreakLockedDurationPercent"></label>
+        <input type="range" min="0" max="100" step="5" list="tickmarksMiniBreakLockedDurationPercent" name="microbreakLockedDurationPercent" data-divisor="1" id="miniBreakLockedDurationPercent">
+        <datalist id="tickmarksMiniBreakLockedDurationPercent">
+          <option value="0"></option>
+          <option value="5"></option>
+          <option value="10"></option>
+          <option value="15"></option>
+          <option value="20"></option>
+          <option value="25"></option>
+          <option value="30"></option>
+          <option value="35"></option>
+          <option value="40"></option>
+          <option value="45"></option>
+          <option value="50"></option>
+          <option value="55"></option>
+          <option value="60"></option>
+          <option value="65"></option>
+          <option value="70"></option>
+          <option value="75"></option>
+          <option value="80"></option>
+          <option value="85"></option>
+          <option value="90"></option>
+          <option value="95"></option>
+          <option value="100"></option>
+        </datalist>
+        <output data-unit="percent"></output>
+      </div>
+      <div>
         <label data-i18next="contributorPreferences.postponeFor" data-same-width-label for="miniBreakPostponeTime"></label>
         <input type="range" min="1" max="10" step="1" list="tickmarksMiniBreakPostponeTime" name="microbreakPostponeTime" data-divisor="60000" id="miniBreakPostponeTime">
         <datalist id="tickmarksMiniBreakPostponeTime">
@@ -155,6 +183,34 @@
         <label data-i18next="contributorPreferences.postponableFor" data-same-width-label for="longBreakPostponableDurationPercent"></label>
         <input type="range" min="5" max="100" step="5" list="tickmarksLongBreakPostponableDurationPercent" name="breakPostponableDurationPercent" data-divisor="1" id="longBreakPostponableDurationPercent">
         <datalist id="tickmarksLongBreakPostponableDurationPercent">
+          <option value="5"></option>
+          <option value="10"></option>
+          <option value="15"></option>
+          <option value="20"></option>
+          <option value="25"></option>
+          <option value="30"></option>
+          <option value="35"></option>
+          <option value="40"></option>
+          <option value="45"></option>
+          <option value="50"></option>
+          <option value="55"></option>
+          <option value="60"></option>
+          <option value="65"></option>
+          <option value="70"></option>
+          <option value="75"></option>
+          <option value="80"></option>
+          <option value="85"></option>
+          <option value="90"></option>
+          <option value="95"></option>
+          <option value="100"></option>
+        </datalist>
+        <output data-unit="percent"></output>
+      </div>
+      <div>
+        <label data-i18next="contributorPreferences.lockedFor" data-same-width-label for="longBreakLockedDurationPercent"></label>
+        <input type="range" min="0" max="100" step="5" list="tickmarksLongBreakLockedDurationPercent" name="breakLockedDurationPercent" data-divisor="1" id="longBreakLockedDurationPercent">
+        <datalist id="tickmarksLongBreakLockedDurationPercent">
+          <option value="0"></option>
           <option value="5"></option>
           <option value="10"></option>
           <option value="15"></option>

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -138,6 +138,7 @@
     "breakPostponeInfo": "If enabled in main Preferences, you can postpone breaks. Following settings allow you to specify when, for how long and how many times you can postpone a break.",
     "miniBreaks": "Mini breaks:",
     "postponableFor": "Postponable for:",
+    "lockedFor": "No skip or postpone for:",
     "postponeFor": "Postpone for:",
     "maxPostpones": "Maximum postpones:",
     "longBreaks": "Long breaks:",

--- a/app/locales/en.json
+++ b/app/locales/en.json
@@ -180,6 +180,7 @@
   },
   "utils": {
     "remaining": "{{count}} remaining",
+    "skippableIn": "Skippable in {{count}}",
     "elapsed": "{{count}} elapsed",
     "inAbout": "in about {{count}}",
     "none_one": "{{count}}",

--- a/app/main.js
+++ b/app/main.js
@@ -767,6 +767,7 @@ function startMicrobreak () {
   const strictMode = settings.get('microbreakStrictMode')
   const postponesLimit = settings.get('microbreakPostponesLimit')
   const postponableDurationPercent = settings.get('microbreakPostponableDurationPercent')
+  const lockedDurationPercent = settings.get('microbreakLockedDurationPercent')
   const postponable = settings.get('microbreakPostpone') &&
     breakPlanner.postponesNumber < postponesLimit && postponesLimit > 0
   const showBreaksAsRegularWindows = settings.get('showBreaksAsRegularWindows')
@@ -796,9 +797,9 @@ function startMicrobreak () {
           finishMicrobreak(false)
           return
         }
-        if (canPostpone(postponable, passedPercent, postponableDurationPercent)) {
+        if (canPostpone(postponable, passedPercent, postponableDurationPercent, lockedDurationPercent)) {
           postponeMicrobreak()
-        } else if (canSkip(strictMode, postponable, passedPercent, postponableDurationPercent)) {
+        } else if (canSkip(strictMode, postponable, passedPercent, postponableDurationPercent, lockedDurationPercent)) {
           increaseDanger(1)
           finishMicrobreak(false)
         }
@@ -806,7 +807,8 @@ function startMicrobreak () {
     }
     return [idea, startTime, breakDuration, strictMode,
       postponable, postponableDurationPercent,
-      calculateBackgroundColor(settings.get('miniBreakColor')), danger, settings.get('breakHealthMode')]
+      calculateBackgroundColor(settings.get('miniBreakColor')), danger,
+      settings.get('breakHealthMode'), lockedDurationPercent]
   })
 
   const contentDisplayId = displayManager.getContentDisplayId()
@@ -935,6 +937,7 @@ function startBreak () {
   const strictMode = settings.get('breakStrictMode')
   const postponesLimit = settings.get('breakPostponesLimit')
   const postponableDurationPercent = settings.get('breakPostponableDurationPercent')
+  const lockedDurationPercent = settings.get('breakLockedDurationPercent')
   const postponable = settings.get('breakPostpone') &&
     breakPlanner.postponesNumber < postponesLimit && postponesLimit > 0
   const showBreaksAsRegularWindows = settings.get('showBreaksAsRegularWindows')
@@ -965,9 +968,9 @@ function startBreak () {
           finishBreak(false)
           return
         }
-        if (canPostpone(postponable, passedPercent, postponableDurationPercent)) {
+        if (canPostpone(postponable, passedPercent, postponableDurationPercent, lockedDurationPercent)) {
           postponeBreak()
-        } else if (canSkip(strictMode, postponable, passedPercent, postponableDurationPercent)) {
+        } else if (canSkip(strictMode, postponable, passedPercent, postponableDurationPercent, lockedDurationPercent)) {
           increaseDanger(2)
           finishBreak(false)
         }
@@ -975,7 +978,8 @@ function startBreak () {
     }
     return [idea, startTime, breakDuration, strictMode,
       postponable, postponableDurationPercent,
-      calculateBackgroundColor(settings.get('mainColor')), danger, settings.get('breakHealthMode')]
+      calculateBackgroundColor(settings.get('mainColor')), danger,
+      settings.get('breakHealthMode'), lockedDurationPercent]
   })
 
   const contentDisplayId = displayManager.getContentDisplayId()

--- a/app/microbreak-renderer.js
+++ b/app/microbreak-renderer.js
@@ -5,7 +5,8 @@ import './platform.js'
 
 window.onload = async (event) => {
   const [idea, started, duration, strictMode, postpone,
-    postponePercent, backgroundColor, danger, breakHealthMode] = await window.breaks.sendBreakData()
+    postponePercent, backgroundColor, danger, breakHealthMode,
+    lockedPercent] = await window.breaks.sendBreakData()
 
   document.ondragover = event =>
     event.preventDefault()
@@ -85,12 +86,12 @@ window.onload = async (event) => {
     if (!manualAwaiting) {
       if (passed < duration) {
         const passedPercent = passed / duration * 100
-        if (window.utils.canPostpone(postpone, passedPercent, postponePercent)) {
+        if (window.utils.canPostpone(postpone, passedPercent, postponePercent, lockedPercent)) {
           postponeElement.classList.remove('hidden')
         } else {
           postponeElement.classList.add('hidden')
         }
-        if (window.utils.canSkip(strictMode, postpone, passedPercent, postponePercent)) {
+        if (window.utils.canSkip(strictMode, postpone, passedPercent, postponePercent, lockedPercent)) {
           closeElement.classList.remove('hidden')
         } else {
           closeElement.classList.add('hidden')

--- a/app/microbreak-renderer.js
+++ b/app/microbreak-renderer.js
@@ -55,6 +55,7 @@ window.onload = async (event) => {
   const progressTime = document.querySelector('#progress-time')
   const postponeElement = document.querySelector('#postpone')
   const closeElement = document.querySelector('#close')
+  const lockHintElement = document.querySelector('#lock-hint')
   const manualFinishElement = document.querySelector('#finish')
   document.body.classList.add(mainColor.substring(1))
   document.body.style.backgroundColor = backgroundColor
@@ -95,6 +96,15 @@ window.onload = async (event) => {
           closeElement.classList.remove('hidden')
         } else {
           closeElement.classList.add('hidden')
+        }
+        if (lockedPercent > 0 && passedPercent < lockedPercent) {
+          lockHintElement.classList.remove('hidden')
+          if (secondChanged) {
+            lockHintElement.innerHTML = await window.utils.formatSkippableIn(
+              duration * lockedPercent / 100 - passed, locale)
+          }
+        } else {
+          lockHintElement.classList.add('hidden')
         }
         progress.value = (100 - passedPercent) * progress.max / 100
         if (secondChanged) {

--- a/app/microbreak.html
+++ b/app/microbreak.html
@@ -19,6 +19,7 @@
         <span id='progress-time' aria-hidden="true"></span>
       </div>
       <div>
+        <span id="lock-hint" class="hidden" aria-live="polite"></span>
         <a id="postpone" class="tooltip top hidden">
           <span data-i18next="break.postpone"></span>
           <img src="images/breaks/break-postpone.svg" />

--- a/app/utils/context-bridge-exposers.js
+++ b/app/utils/context-bridge-exposers.js
@@ -108,6 +108,9 @@ function exposeUtils () {
     formatTimeRemaining: async (milliseconds, locale) => {
       return utils.formatTimeRemaining(milliseconds, locale, i18n, humanizeDuration)
     },
+    formatSkippableIn: async (milliseconds, locale) => {
+      return utils.formatSkippableIn(milliseconds, locale, i18n, humanizeDuration)
+    },
     formatElapsedDuration: async (milliseconds, locale) => {
       return utils.formatElapsedDuration(milliseconds, locale, i18n, humanizeDuration)
     },

--- a/app/utils/defaultSettings.js
+++ b/app/utils/defaultSettings.js
@@ -24,6 +24,8 @@ export default {
   microbreakPostponableDurationPercent: 30,
   breakPostponesLimit: 1,
   breakPostponableDurationPercent: 30,
+  microbreakLockedDurationPercent: 0,
+  breakLockedDurationPercent: 0,
   mainColor: '#478484',
   miniBreakColor: '#478484',
   transparentMode: false,

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -47,14 +47,21 @@ function formatUnitAndValue (unit, value, i18next) {
   }
 }
 
-// does not consider `postponesLimit`
-function canPostpone (postpone, passedPercent, postponePercent) {
-  return postpone && passedPercent <= postponePercent
+// exits are locked for the opening `lockedPercent` of the break
+function isLocked (passedPercent, lockedPercent) {
+  return passedPercent < lockedPercent
 }
 
 // does not consider `postponesLimit`
-function canSkip (strictMode, postpone, passedPercent, postponePercent) {
-  return !((postpone && passedPercent <= postponePercent) || strictMode)
+function canPostpone (postpone, passedPercent, postponePercent, lockedPercent = 0) {
+  return !isLocked(passedPercent, lockedPercent) &&
+    postpone && passedPercent <= postponePercent
+}
+
+// does not consider `postponesLimit`
+function canSkip (strictMode, postpone, passedPercent, postponePercent, lockedPercent = 0) {
+  return !isLocked(passedPercent, lockedPercent) &&
+    !((postpone && passedPercent <= postponePercent) || strictMode)
 }
 
 function formatKeyboardShortcut (keyboardShortcut) {

--- a/app/utils/utils.js
+++ b/app/utils/utils.js
@@ -10,6 +10,16 @@ function formatTimeRemaining (milliseconds, locale, i18next, humanizeDuration) {
   })
 }
 
+function formatSkippableIn (milliseconds, locale, i18next, humanizeDuration) {
+  if (locale === 'pt-BR') {
+    locale = 'pt'
+  }
+  return i18next.t('utils.skippableIn', {
+    count: humanizeDuration(milliseconds,
+      { round: true, delimiter: ' ', language: locale.replace('-', '_'), fallbacks: ['en'] })
+  })
+}
+
 function formatElapsedDuration (milliseconds, locale, i18next, humanizeDuration) {
   if (locale === 'pt-BR') {
     locale = 'pt'
@@ -118,6 +128,7 @@ function getLinuxDisplayBackend (ozonePlatform = '', runtime = process) {
 
 export {
   formatTimeRemaining,
+  formatSkippableIn,
   formatElapsedDuration,
   formatTimeIn,
   formatUnitAndValue,

--- a/test/utils.js
+++ b/test/utils.js
@@ -143,6 +143,29 @@ describe('Others', () => {
     })
   })
 
+  describe('lockedDurationPercent', () => {
+    // no exits are offered before lockedPercent of the break has elapsed
+    it('locks skip before locked percent', () => {
+      canSkip(false, false, 3, 30, 5).should.equal(false)
+    })
+    it('offers skip at locked percent', () => {
+      canSkip(false, false, 5, 30, 5).should.equal(true)
+    })
+    it('locks postpone before locked percent', () => {
+      canPostpone(true, 3, 30, 5).should.equal(false)
+    })
+    it('offers postpone at locked percent', () => {
+      canPostpone(true, 5, 30, 5).should.equal(true)
+    })
+    it('is inert when zero, keeping default behaviour', () => {
+      canSkip(false, false, 0, 30, 0).should.equal(true)
+      canPostpone(true, 0, 30, 0).should.equal(true)
+    })
+    it('never overrides strict mode', () => {
+      canSkip(true, false, 90, 30, 5).should.equal(false)
+    })
+  })
+
   describe('formatKeyboardShortcut', () => {
     it('formats Or to /', () => {
       formatKeyboardShortcut('CmdOrCtrl+X').should.equal('Cmd/Ctrl + X')


### PR DESCRIPTION
## Why

Skip and Postpone are currently two halves of a single predicate:

```js
canPostpone(postpone, pp, P) => postpone && pp <= P
canSkip(strict, postpone, pp, P) => !((postpone && pp <= P) || strict)
```

Hiding Skip during the opening moments of a break therefore *requires* `postponable` to be true, which necessarily *shows* Postpone during those same moments. There is no configuration in which a break simply cannot be dismissed for its first few seconds — the only "no exit" option is `strictMode`, which locks the break for its whole duration.

That leaves a gap for people who want a break they cannot reflexively dismiss, but who do not want to be trapped for ten minutes. The muscle-memory click lands before the eyes have left the screen, which is the moment the break exists to interrupt.

Refs #1841, #1629.

## What

Two new settings, `microbreakLockedDurationPercent` and `breakLockedDurationPercent`, both defaulting to `0`.

While the break is younger than that percentage of its duration, neither Skip nor Postpone is offered and the keyboard shortcut is inert. Once it elapses, existing behaviour resumes unchanged.

At `0` the predicates are exactly as before — the new argument is optional and defaults to `0`, so every existing call site and test is untouched:

```js
function canSkip (strictMode, postpone, passedPercent, postponePercent, lockedPercent = 0) {
  return !isLocked(passedPercent, lockedPercent) &&
    !((postpone && passedPercent <= postponePercent) || strictMode)
}
```

The second commit adds the user-facing half: while exits are locked, `Skippable in <time>` appears where the buttons will be, counting down on the existing per-second tick. It is one translatable key with a `{{count}}` placeholder (`utils.skippableIn`, formatted by a new `formatSkippableIn` beside `formatTimeRemaining`) rather than a prefix concatenated onto a formatted duration — languages that place the verb differently from English can then be translated correctly. Marked `aria-live="polite"` so assistive technology can explain why nothing is actionable yet.

## Open question for the maintainer

I expressed the lock as a **percentage of break duration**, reusing the existing `PostponableDurationPercent` plumbing and slider. #1841 asked for a delay in **seconds**, which is how users think about it, but that needs its own unit handling and a different control.

Happy to switch to milliseconds if you prefer — it is a small change and I would rather match your intent than my convenience.

## Testing

- `standard` clean.
- `vitest run` — 45/45 passing, including 6 new cases covering the lock boundary, inertness at `0`, and that it never overrides `strictMode`.
- Packed with `npm run pack` and exercised on Windows 11: microbreaks remain strict throughout, a 10-minute long break offers nothing for its first 30 seconds and shows a live countdown, then Skip appears.

## Not included

Translations. `en.json` only, since the other 53 locales are managed on Weblate.
